### PR TITLE
feat: merge pilot-load tuning into kind-c1.yaml

### DIFF
--- a/scripts/create_cluster.sh
+++ b/scripts/create_cluster.sh
@@ -47,20 +47,49 @@ delete_kind_cluster(){
             done
             fi
         fi
+    sudo rm -rf /home/ben/.kind/etcd-c1 && mkdir -p /home/ben/.kind/etcd-c1
     echo "end delete_kind_cluster() .."
+}
+
+get_node_image(){
+    case "$kind_version" in
+        v0.14.0) echo "kindest/node:v1.24.0" ;;
+        v0.23.0) echo "kindest/node:v1.27.3" ;;
+        v0.26.0) echo "kindest/node:v1.29.2" ;;
+        *) echo "" ;;
+    esac
+}
+
+build_kind_config(){
+    local base_config="$1"
+    local tmp_config
+    tmp_config=$(mktemp /tmp/kind-config.XXXXXX.yaml)
+    cp "$base_config" "$tmp_config"
+    # extraMounts on /var/lib/etcd only works on kind v0.26.0+
+    if [[ "$kind_version" == "v0.26.0" ]]; then
+        mkdir -p /home/ben/.kind/etcd-c1
+        cat >> "$tmp_config" << 'EOF'
+    extraMounts:
+      - hostPath: /home/ben/.kind/etcd-c1
+        containerPath: /var/lib/etcd
+EOF
+    fi
+    echo "$tmp_config"
 }
 
 create_kind_cluster(){
     echo "start create_kind_cluster() .."
+    local node_image=$(get_node_image)
+    local image_flag=""
+    [[ -n "$node_image" ]] && image_flag="--image=$node_image"
+
     if [[ "$cluster_mode" == "multi" ]]; then
-        # 創建多集群模式下的集群
         echo "創建集群 c1 和 c2"
-        kind create cluster --name=c1 --config="$FILE_PATH_kind"
-        kind create cluster --name=c2 --config="$FILE_PATH_kind_2"
+        kind create cluster --name=c1 $image_flag --config="$(build_kind_config $FILE_PATH_kind)"
+        kind create cluster --name=c2 $image_flag --config="$FILE_PATH_kind_2"
     elif [[ "$cluster_mode" == "single" ]]; then
-        # 單集群模式
         echo "創建集群 c1"
-        kind create cluster --name=c1 --config=$FILE_PATH_kind
+        kind create cluster --name=c1 $image_flag --config="$(build_kind_config $FILE_PATH_kind)"
     else
         echo "please check agin :  $cluster_mode 。"
         exit 1

--- a/tools/kind/kind-c1.yaml
+++ b/tools/kind/kind-c1.yaml
@@ -1,7 +1,27 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
+name: c1
 networking:
   podSubnet: "172.18.10.0/24"
+
 nodes:
-# the control plane node config
-- role: control-plane
+  - role: control-plane
+    kubeadmConfigPatches:
+      - |
+        kind: ClusterConfiguration
+        apiServer:
+          extraArgs:
+            max-requests-inflight: "2000"
+            max-mutating-requests-inflight: "1000"
+            default-watch-cache-size: "500"
+        etcd:
+          local:
+            extraArgs:
+              quota-backend-bytes: "8589934592"   # 8Gi
+              snapshot-count: "5000"
+      - |
+        kind: KubeletConfiguration
+        maxPods: 250
+    extraMounts:
+      - hostPath: /tmp/kind-etcd-c1
+        containerPath: /var/lib/etcd

--- a/tools/kind/kind-c1.yaml
+++ b/tools/kind/kind-c1.yaml
@@ -22,6 +22,3 @@ nodes:
       - |
         kind: KubeletConfiguration
         maxPods: 250
-    extraMounts:
-      - hostPath: /tmp/kind-etcd-c1
-        containerPath: /var/lib/etcd


### PR DESCRIPTION
## Summary

- 合併 pilot-load 壓測調校到 `kind-c1.yaml`（API server / etcd / kubelet extraArgs）
- `kind-c1.yaml` 改為 version-agnostic，node image 與 etcd mount 由 script 動態決定
- `create_cluster.sh` 新增 `get_node_image()` 與 `build_kind_config()`
- etcd hostPath mount（`/home/ben/.kind/etcd-c1`）僅 v0.26.0 自動注入

## Test plan

- [x] v0.14.0 (kindest/node:v1.24.0) — cluster 建立 ✅、kubeadmConfigPatches ✅
- [x] v0.23.0 (kindest/node:v1.27.3) — cluster 建立 ✅、kubeadmConfigPatches ✅
- [x] v0.26.0 (kindest/node:v1.29.2) — cluster 建立 ✅、kubeadmConfigPatches ✅、etcd extraMounts ✅
- [x] 完整 main.sh 流程（Istio + sample app + metallb）✅

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)