### PR TITLE
release: sync 1-feat-develop → main (2026-04-18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ kind-create-cluster/
 ├── config/   # Kubernetes configuration files
 ├── samples/  # Example YAML files
 ├── scripts/  # Automation scripts
-├── test/     # Testing-related resources
 ├── tools/    # Utilities or helper programs
 └── README.md # Project documentation
 ```
@@ -21,17 +20,18 @@ kind-create-cluster/
    Modify the configuration files to set the required versions for **Kind**, **Istio**, **Kiali**, and other related components.
 
 2. **Review Execution Steps**  
-   Check the steps defined in `script/main` to understand the execution flow.
+   Check the steps defined in `scripts/main.sh` to understand the execution flow.
 
 3. **Run the Script**  
    Execute the following command to start:
    ```
-   ./script/main.sh
+   ./scripts/main.sh
    ```
 
 #### Frequently used commands
 ```
-[ $(uname -m) = x86_64 ] && curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.26.0/kind-linux-amd64
+# kind version is defined in config/config.env (kind_version)
+[ $(uname -m) = x86_64 ] && curl -Lo ./kind https://kind.sigs.k8s.io/dl/${kind_version}/kind-linux-amd64
 wget "https://github.com/istio/istio/releases/download/1.25.5/istio-1.25.5-linux-amd64.tar.gz" -O - | tar -xz 
 cp tools/istio/certs/cluster1-1.24.0.yaml  .
 mv cluster1-1.24.0.yaml cluster-1.24.0.yaml
@@ -171,5 +171,4 @@ kubectl -n test create secret tls ngx-service-tls \
 kubectl patch svc istio-ingressgateway -n istio-system -p '{"spec": {"type": "LoadBalancer"}}'
 istioctl x uninstall --revision=1-17-3
 code --no-sandbox --user-data-dir="/path/to/your/directory"
-git push -u origin 12-feat-develop
 ```

--- a/scripts/create_cluster.sh
+++ b/scripts/create_cluster.sh
@@ -47,20 +47,49 @@ delete_kind_cluster(){
             done
             fi
         fi
+    sudo rm -rf /home/ben/.kind/etcd-c1 && mkdir -p /home/ben/.kind/etcd-c1
     echo "end delete_kind_cluster() .."
+}
+
+get_node_image(){
+    case "$kind_version" in
+        v0.14.0) echo "kindest/node:v1.24.0" ;;
+        v0.23.0) echo "kindest/node:v1.27.3" ;;
+        v0.26.0) echo "kindest/node:v1.29.2" ;;
+        *) echo "" ;;
+    esac
+}
+
+build_kind_config(){
+    local base_config="$1"
+    local tmp_config
+    tmp_config=$(mktemp /tmp/kind-config.XXXXXX.yaml)
+    cp "$base_config" "$tmp_config"
+    # extraMounts on /var/lib/etcd only works on kind v0.26.0+
+    if [[ "$kind_version" == "v0.26.0" ]]; then
+        mkdir -p /home/ben/.kind/etcd-c1
+        cat >> "$tmp_config" << 'EOF'
+    extraMounts:
+      - hostPath: /home/ben/.kind/etcd-c1
+        containerPath: /var/lib/etcd
+EOF
+    fi
+    echo "$tmp_config"
 }
 
 create_kind_cluster(){
     echo "start create_kind_cluster() .."
+    local node_image=$(get_node_image)
+    local image_flag=""
+    [[ -n "$node_image" ]] && image_flag="--image=$node_image"
+
     if [[ "$cluster_mode" == "multi" ]]; then
-        # 創建多集群模式下的集群
         echo "創建集群 c1 和 c2"
-        kind create cluster --name=c1 --config="$FILE_PATH_kind"
-        kind create cluster --name=c2 --config="$FILE_PATH_kind_2"
+        kind create cluster --name=c1 $image_flag --config="$(build_kind_config $FILE_PATH_kind)"
+        kind create cluster --name=c2 $image_flag --config="$FILE_PATH_kind_2"
     elif [[ "$cluster_mode" == "single" ]]; then
-        # 單集群模式
         echo "創建集群 c1"
-        kind create cluster --name=c1 --config=$FILE_PATH_kind
+        kind create cluster --name=c1 $image_flag --config="$(build_kind_config $FILE_PATH_kind)"
     else
         echo "please check agin :  $cluster_mode 。"
         exit 1

--- a/tools/kind/kind-c1.yaml
+++ b/tools/kind/kind-c1.yaml
@@ -1,7 +1,27 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
+name: c1
 networking:
   podSubnet: "172.18.10.0/24"
+
 nodes:
-# the control plane node config
-- role: control-plane
+  - role: control-plane
+    kubeadmConfigPatches:
+      - |
+        kind: ClusterConfiguration
+        apiServer:
+          extraArgs:
+            max-requests-inflight: "2000"
+            max-mutating-requests-inflight: "1000"
+            default-watch-cache-size: "500"
+        etcd:
+          local:
+            extraArgs:
+              quota-backend-bytes: "8589934592"   # 8Gi
+              snapshot-count: "5000"
+      - |
+        kind: KubeletConfiguration
+        maxPods: 250
+    extraMounts:
+      - hostPath: /tmp/kind-etcd-c1
+        containerPath: /var/lib/etcd

--- a/tools/kind/kind-c1.yaml
+++ b/tools/kind/kind-c1.yaml
@@ -22,6 +22,3 @@ nodes:
       - |
         kind: KubeletConfiguration
         maxPods: 250
-    extraMounts:
-      - hostPath: /tmp/kind-etcd-c1
-        containerPath: /var/lib/etcd


### PR DESCRIPTION
## Summary

將 `1-feat-develop` 的今日改動合併至 `main`。

## 包含的變更

| commit | 日期時間 | 說明 |
|--------|----------|------|
| `f00d546` | 2026-04-18 22:30 | PR #12 merge（README cleanup）|
| `802319c` | 2026-04-18 22:28 | chore: README cleanup |
| `c731bb7` | 2026-04-18 22:24 | PR #10 merge（pilot-load tuning）|
| `de48d22` | 2026-04-18 22:20 | feat: version-agnostic kind config |
| `28daede` | 2026-04-18 21:28 | feat: pilot-load tuning |

## 關聯 Issues

- Closes #9
- Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)