### PR TITLE
feat: restructure project to support one-click c1/c2 sidecar mode Istio mesh via kind

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+.PHONY: help c1-sidecar c1c2-singlenet clean
+
+help:
+	@echo "Usage:"
+	@echo "  make c1-sidecar      Create single cluster (c1) with sidecar mode Istio"
+	@echo "  make c1c2-singlenet  Create dual clusters (c1 + c2) with sidecar mode Istio multi-primary mesh (single network)"
+	@echo "  make clean           Delete all kind clusters and clear download cache"
+
+c1-sidecar:
+	@sed -i 's/^cluster_mode=.*/cluster_mode=single/' config/config.env
+	bash scripts/main.sh
+
+c1c2-singlenet:
+	@sed -i 's/^cluster_mode=.*/cluster_mode=multi/' config/config.env
+	bash scripts/main.sh
+
+clean:
+	bash scripts/create_cluster.sh delete_kind_cluster
+	rm -rf /tmp/download/*

--- a/README.md
+++ b/README.md
@@ -17,16 +17,78 @@ kind-create-cluster/
 #### Getting Started
 
 1. **Update Configurations**  
-   Modify the configuration files to set the required versions for **Kind**, **Istio**, **Kiali**, and other related components.
+   Modify `config/config.env` to set the required versions for **Kind**, **Istio**, **Kiali**, and other components.
 
-2. **Review Execution Steps**  
-   Check the steps defined in `scripts/main.sh` to understand the execution flow.
+2. **Run via Makefile** (recommended)
 
-3. **Run the Script**  
-   Execute the following command to start:
+   | Command | Description |
+   |---|---|
+   | `make c1-sidecar` | Single cluster (c1) with sidecar mode Istio |
+   | `make c1c2-singlenet` | Dual clusters (c1 + c2) with sidecar mode Istio multi-primary mesh (single network) |
+   | `make clean` | Delete all kind clusters and clear download cache |
+
+3. **Or run the script directly**
    ```
+   # single cluster
+   ./scripts/main.sh
+
+   # dual cluster single network — set cluster_mode=multi in config/config.env first
    ./scripts/main.sh
    ```
+
+#### Cluster Architecture
+
+```
+c1 (kind-c1)                        c2 (kind-c2)
+podSubnet: 172.18.10.0/24           podSubnet: 172.18.11.0/24
+Istio profile: default              Istio profile: default
+meshID: mesh1                       meshID: mesh1
+clusterName: cluster1               clusterName: cluster2
+network: network1                   network: network1
+          ↕  cross-cluster remote secret (mesh.sh)
+          ↕  static pod-subnet routes (single network)
+```
+
+#### Verify Istio Mesh (c1/c2)
+
+**1. Check istiod status**
+```bash
+kubectl --context kind-c1 get pod -n istio-system -l app=istiod
+kubectl --context kind-c2 get pod -n istio-system -l app=istiod
+```
+
+**2. Check sidecar injection (pods should be 2/2)**
+```bash
+kubectl --context kind-c1 get pod -n sample
+kubectl --context kind-c2 get pod -n sample
+```
+
+**3. Check remote secrets (cross-cluster discovery)**
+```bash
+kubectl --context kind-c1 get secret -n istio-system istio-remote-secret-cluster2
+kubectl --context kind-c2 get secret -n istio-system istio-remote-secret-cluster1
+```
+
+**4. Verify shared root CA**
+```bash
+kubectl --context kind-c1 -n istio-system get secret cacerts -ojsonpath='{.data.root-cert\.pem}' > /tmp/c1-root.pem
+kubectl --context kind-c2 -n istio-system get secret cacerts -ojsonpath='{.data.root-cert\.pem}' > /tmp/c2-root.pem
+cmp /tmp/c1-root.pem /tmp/c2-root.pem && echo "OK: cacerts identical" || echo "FAIL: cacerts differ"
+```
+
+**5. Cross-cluster routing test (c1 → helloworld, expect v1/v2 alternating)**
+```bash
+for i in $(seq 1 10); do
+  kubectl --context kind-c1 exec -n sample deploy/sleep -- curl -s helloworld.sample.svc.cluster.local:5000/hello
+done
+```
+
+**6. Reverse test (c2 → helloworld)**
+```bash
+for i in $(seq 1 10); do
+  kubectl --context kind-c2 exec -n sample deploy/sleep -- curl -s helloworld.sample.svc.cluster.local:5000/hello
+done
+```
 
 #### Frequently used commands
 ```

--- a/config/config.env
+++ b/config/config.env
@@ -8,7 +8,7 @@ istio_version=1.24.0  # istio vesion : [ 1.13.5 , 1.23.0 ,1.24.0]
 istio_label=1-24-0  # istio vesion : [ 1-13-5 , 1-23-0 ,1-24-0]
 kiali_version=v1.49.0 # kiali version: [ v1.49.0 , v1.87.0 , v2.0.0]
 
-cluster_mode=single # cluster_mode: [ single , multi ]
+cluster_mode=multi
 
 available_processes=("main" "pretask" "create_kind_cluster" "istio" "prometheus" "kiali" "clear")
 filtered_version_kiali=$(echo "$kiali_version" | tr -d 'v')

--- a/scripts/main.sh
+++ b/scripts/main.sh
@@ -14,7 +14,9 @@ main_task(){
     bash $abspath/scripts/deploy-nginx.sh
     # bash $abspath/scripts/istio_consistent_hash.sh
     bash $abspath/scripts/metallb.sh
-    # bash $abspath/scripts/mesh.sh
+    if [[ "$cluster_mode" == "multi" ]]; then
+        bash $abspath/scripts/mesh.sh
+    fi
 }
 
 clear(){

--- a/scripts/mesh.sh
+++ b/scripts/mesh.sh
@@ -48,40 +48,18 @@ check_cacerts(){
     fi
 }
 
-appdend_ip_mac(){  
-    # get ns/sample pod's ip     
-    sleep_ip_c1=$(kubectl -n sample --context="${CTX_CLUSTER1}" get pod -l app=sleep -o jsonpath='{.items[0].status.podIP}')
-    helloworld_ip_c1=$(kubectl -n sample --context="${CTX_CLUSTER1}" get pod -l app=helloworld -o jsonpath='{.items[0].status.podIP}')
+add_cross_cluster_routes(){
+    c1_master_ip=$(docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' c1-control-plane)
+    c2_master_ip=$(docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' c2-control-plane)
 
-    sleep_ip_c2=$(kubectl -n sample --context="${CTX_CLUSTER2}" get pod -l app=sleep -o jsonpath='{.items[0].status.podIP}')
-    helloworld_ip_c2=$(kubectl -n sample --context="${CTX_CLUSTER2}" get pod -l app=helloworld -o jsonpath='{.items[0].status.podIP}')
+    c1_pod_subnet=$(kubectl --context="${CTX_CLUSTER1}" get node c1-control-plane -o jsonpath='{.spec.podCIDR}')
+    c2_pod_subnet=$(kubectl --context="${CTX_CLUSTER2}" get node c2-control-plane -o jsonpath='{.spec.podCIDR}')
 
-    echo "Sleep Pod IP in Cluster1: $sleep_ip_c1"
-    echo "Helloworld Pod IP in Cluster1: $helloworld_ip_c1"
-    echo "Sleep Pod IP in Cluster2: $sleep_ip_c2"
-    echo "Helloworld Pod IP in Cluster2: $helloworld_ip_c2"   
+    echo "Adding route: c1 → $c2_pod_subnet via $c2_master_ip"
+    docker exec c1-control-plane ip route add "$c2_pod_subnet" via "$c2_master_ip" 2>/dev/null || echo "route already exists"
 
-    docker exec -it c1-control-plane bash -c "
-    apt-get update && apt-get install -y net-tools && 
-    echo 'Installation completed on c1-control-plane'
-    " && \
-    docker exec -it c2-control-plane bash -c "
-        apt-get update && apt-get install -y net-tools && 
-        echo 'Installation completed on c2-control-plane'
-    "
-    # mac_address_c1=$(docker exec c1-control-plane bash -c "arp -n | grep '$c1_master_ip' | awk '{print \$3}'")
-    # mac_address_c2=$(docker exec c1-control-plane bash -c "arp -n | grep '$c1_master_ip' | awk '{print \$3}'")
-    
-    # echo mac_address_c1=$mac_address_c1
-    # echo mac_address_c2=$mac_address_c2
-    
-    # get control-plane1's mac
-
-    # get control-plane2's mac    
-
-    # append the helloworld's ip and mac address on control-plane node
-
-
+    echo "Adding route: c2 → $c1_pod_subnet via $c1_master_ip"
+    docker exec c2-control-plane ip route add "$c1_pod_subnet" via "$c1_master_ip" 2>/dev/null || echo "route already exists"
 }
 
 istiod_status=$(kubectl get pod -n istio-system -l app=istiod -o jsonpath='{.items[0].status.phase}')
@@ -91,7 +69,7 @@ namespace_exists=$(kubectl get ns sample --ignore-not-found)
 if [[ "$istiod_status" == "Running" ]]; then
     main_task
     check_cacerts
-    appdend_ip_mac
+    add_cross_cluster_routes
 fi
 
 exit 0

--- a/tools/istio/certs/cluster2-1.24.0.yaml
+++ b/tools/istio/certs/cluster2-1.24.0.yaml
@@ -1,7 +1,7 @@
 apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 spec:
-  profile: ambient
+  profile: default
   revision: 1-24-0
   meshConfig:
     accessLogFile: /dev/stdout

--- a/tools/kind/kind-c2.yaml
+++ b/tools/kind/kind-c2.yaml
@@ -1,7 +1,24 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
+name: c2
 networking:
   podSubnet: "172.18.11.0/24"
+
 nodes:
-# the control plane node config
-- role: control-plane
+  - role: control-plane
+    kubeadmConfigPatches:
+      - |
+        kind: ClusterConfiguration
+        apiServer:
+          extraArgs:
+            max-requests-inflight: "2000"
+            max-mutating-requests-inflight: "1000"
+            default-watch-cache-size: "500"
+        etcd:
+          local:
+            extraArgs:
+              quota-backend-bytes: "8589934592"   # 8Gi
+              snapshot-count: "5000"
+      - |
+        kind: KubeletConfiguration
+        maxPods: 250


### PR DESCRIPTION
## Summary
- Fix `cluster2-1.24.0.yaml` profile `ambient` → `default` (sidecar mode)
- Align `kind-c2.yaml` with c1 (cluster name, performance tuning)
- Enable `mesh.sh` automatically in multi cluster mode
- Replace `appdend_ip_mac` with `add_cross_cluster_routes` — fix `docker exec -it` TTY issue, auto-add pod subnet static routes for single network mesh
- Add `Makefile` with `c1-sidecar` / `c1c2-singlenet` / `clean` targets
- Update README with Makefile usage, cluster architecture diagram, and Istio mesh verification steps

## Test plan
- [x] `make c1c2-singlenet` completes without error
- [x] c1 / c2 istiod Running (sidecar mode, 1/1)
- [x] sample pods 2/2 (sidecar injected)
- [x] remote secrets exchanged between clusters
- [x] cacerts identical across clusters
- [x] cross-cluster routing: c1 sleep → helloworld returns v1/v2 alternating

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)