### PR TITLE
feat: install istio-eastwestgateway after c1c2-singlenet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
-.PHONY: help c1-sidecar c1c2-singlenet clean
+.PHONY: help c1-sidecar c1c2-singlenet c1c2-install-ewgw clean
 
 help:
 	@echo "Usage:"
-	@echo "  make c1-sidecar      Create single cluster (c1) with sidecar mode Istio"
-	@echo "  make c1c2-singlenet  Create dual clusters (c1 + c2) with sidecar mode Istio multi-primary mesh (single network)"
-	@echo "  make clean           Delete all kind clusters and clear download cache"
+	@echo "  make c1-sidecar          Create single cluster (c1) with sidecar mode Istio"
+	@echo "  make c1c2-singlenet      Create dual clusters (c1 + c2) with sidecar mode Istio multi-primary mesh (single network)"
+	@echo "  make c1c2-install-ewgw   Install istio-eastwestgateway on c1 and c2 clusters"
+	@echo "  make clean               Delete all kind clusters and clear download cache"
 
 c1-sidecar:
 	@sed -i 's/^cluster_mode=.*/cluster_mode=single/' config/config.env
@@ -13,6 +14,9 @@ c1-sidecar:
 c1c2-singlenet:
 	@sed -i 's/^cluster_mode=.*/cluster_mode=multi/' config/config.env
 	bash scripts/main.sh
+
+c1c2-install-ewgw:
+	bash scripts/install_eastwestgateway.sh
 
 clean:
 	kind delete cluster --name c1 2>/dev/null || true

--- a/scripts/install_eastwestgateway.sh
+++ b/scripts/install_eastwestgateway.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -e
+abspath=$(cd "$(dirname "$0")/.."; pwd)
+source $abspath/config/config.env
+
+FILE_PATH_ewgw_c1=$abspath/tools/istio/eastwestgateway/cluster1-ewgw-$istio_version.yaml
+FILE_PATH_ewgw_c2=$abspath/tools/istio/eastwestgateway/cluster2-ewgw-$istio_version.yaml
+FILE_PATH_expose=$abspath/tools/istio/eastwestgateway/expose-services.yaml
+
+install_eastwestgateway(){
+    export PATH=$FOLDER_PATH_istio/bin:$PATH
+
+    echo "Installing eastwestgateway on ${CTX_CLUSTER1} ..."
+    istioctl install --context="${CTX_CLUSTER1}" -y -f $FILE_PATH_ewgw_c1
+
+    echo "Installing eastwestgateway on ${CTX_CLUSTER2} ..."
+    istioctl install --context="${CTX_CLUSTER2}" -y -f $FILE_PATH_ewgw_c2
+
+    echo "Exposing services via cross-network-gateway on ${CTX_CLUSTER1} ..."
+    kubectl --context="${CTX_CLUSTER1}" apply -f $FILE_PATH_expose
+
+    echo "Exposing services via cross-network-gateway on ${CTX_CLUSTER2} ..."
+    kubectl --context="${CTX_CLUSTER2}" apply -f $FILE_PATH_expose
+
+    echo "Eastwestgateway installation complete."
+}
+
+install_eastwestgateway
+
+exit 0

--- a/tools/istio/certs/cluster1-1.24.0.yaml
+++ b/tools/istio/certs/cluster1-1.24.0.yaml
@@ -15,13 +15,6 @@ spec:
         hpaSpec:
           minReplicas: 1
           maxReplicas: 1
-        overlays:
-        - apiVersion: apps/v1
-          kind: Service
-          name: istio-ingressgateway
-          patches:
-            - path: spec.type
-              value: ClusterIP
     pilot:
       k8s:
         env:

--- a/tools/istio/certs/cluster2-1.24.0.yaml
+++ b/tools/istio/certs/cluster2-1.24.0.yaml
@@ -15,13 +15,6 @@ spec:
         hpaSpec:
           minReplicas: 1
           maxReplicas: 1
-        overlays:
-        - apiVersion: apps/v1
-          kind: Service
-          name: istio-ingressgateway
-          patches:
-            - path: spec.type
-              value: ClusterIP
     pilot:
       k8s:
         env:

--- a/tools/istio/eastwestgateway/cluster1-ewgw-1.24.0.yaml
+++ b/tools/istio/eastwestgateway/cluster1-ewgw-1.24.0.yaml
@@ -1,0 +1,41 @@
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+metadata:
+  name: eastwest
+spec:
+  revision: 1-24-0
+  profile: empty
+  components:
+    ingressGateways:
+      - name: istio-eastwestgateway
+        label:
+          istio: eastwestgateway
+          app: istio-eastwestgateway
+          topology.istio.io/network: network1
+        enabled: true
+        k8s:
+          env:
+            - name: ISTIO_META_ROUTER_MODE
+              value: "sni-dnat"
+            - name: ISTIO_META_REQUESTED_NETWORK_VIEW
+              value: network1
+          service:
+            ports:
+              - name: status-port
+                port: 15021
+                targetPort: 15021
+              - name: tls
+                port: 15443
+                targetPort: 15443
+              - name: tls-istiod
+                port: 15012
+                targetPort: 15012
+              - name: tls-webhook
+                port: 15017
+                targetPort: 15017
+  values:
+    gateways:
+      istio-ingressgateway:
+        injectionTemplate: gateway
+    global:
+      network: network1

--- a/tools/istio/eastwestgateway/cluster2-ewgw-1.24.0.yaml
+++ b/tools/istio/eastwestgateway/cluster2-ewgw-1.24.0.yaml
@@ -1,0 +1,41 @@
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+metadata:
+  name: eastwest
+spec:
+  revision: 1-24-0
+  profile: empty
+  components:
+    ingressGateways:
+      - name: istio-eastwestgateway
+        label:
+          istio: eastwestgateway
+          app: istio-eastwestgateway
+          topology.istio.io/network: network1
+        enabled: true
+        k8s:
+          env:
+            - name: ISTIO_META_ROUTER_MODE
+              value: "sni-dnat"
+            - name: ISTIO_META_REQUESTED_NETWORK_VIEW
+              value: network1
+          service:
+            ports:
+              - name: status-port
+                port: 15021
+                targetPort: 15021
+              - name: tls
+                port: 15443
+                targetPort: 15443
+              - name: tls-istiod
+                port: 15012
+                targetPort: 15012
+              - name: tls-webhook
+                port: 15017
+                targetPort: 15017
+  values:
+    gateways:
+      istio-ingressgateway:
+        injectionTemplate: gateway
+    global:
+      network: network1

--- a/tools/istio/eastwestgateway/expose-services.yaml
+++ b/tools/istio/eastwestgateway/expose-services.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: cross-network-gateway
+  namespace: istio-system
+spec:
+  selector:
+    istio: eastwestgateway
+  servers:
+    - port:
+        number: 15443
+        name: tls
+        protocol: TLS
+      tls:
+        mode: AUTO_PASSTHROUGH
+      hosts:
+        - "*.local"


### PR DESCRIPTION
## Summary

- 新增 `make c1c2-install-ewgw` 獨立 target，在 `make c1c2-singlenet` 後安裝 istio-eastwestgateway
- 新增 `scripts/install_eastwestgateway.sh`，於 c1/c2 兩個叢集部署 eastwestgateway 並套用 `cross-network-gateway` Gateway 資源
- 新增 `tools/istio/eastwestgateway/` IstioOperator YAML 與 expose-services Gateway 配置
- 移除 `istio-ingressgateway` 的 ClusterIP override，使 MetalLB 正確分配 VIP

Closes #18

## Test plan

- [ ] `make c1c2-singlenet` 執行成功，c1/c2 叢集建立完成
- [ ] `make c1c2-install-ewgw` 執行成功，c1/c2 均出現 `istio-eastwestgateway` pod
- [ ] `istio-eastwestgateway` 與 `istio-ingressgateway` 皆取得 MetalLB VIP (EXTERNAL-IP)
- [ ] `cross-network-gateway` Gateway 資源於兩叢集建立成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)