### PR TITLE
chore: merge 1-feat-develop into main (ewgw network label fix + README update)

### DIFF
--- a/.claude/commands/github-flow.md
+++ b/.claude/commands/github-flow.md
@@ -14,7 +14,7 @@
 
 ### Step 1：收集資訊
 詢問使用者：
-- **Issue 標題**（例如：`feat: add xxx`）
+- **Issue 標題**（例如：`feat: add xxx`，**標題一律使用英文**）
 - **Issue 描述**（問題背景、預計異動）
 - **Branch slug**（例如：`add-xxx`，會自動加上 issue 編號變成 `{number}-add-xxx`）
 - **目標 base branch**（預設 `1-feat-develop`）
@@ -67,6 +67,11 @@ git push origin {issue-number}-$SLUG
 git branch -d {issue-number}-$SLUG
 git push origin --delete {issue-number}-$SLUG
 ```
+
+## Issue 標題準則
+
+- **一律使用英文**撰寫 issue 標題
+- 格式：`<type>: <short description>`，例如 `feat: add xxx`、`fix: xxx not working`、`chore: update xxx`
 
 ## 注意事項
 

--- a/README.md
+++ b/README.md
@@ -39,15 +39,26 @@ kind-create-cluster/
 
 #### Cluster Architecture
 
+**c1c2-singlenet** (single network, direct pod-to-pod routing)
 ```
 c1 (kind-c1)                        c2 (kind-c2)
 podSubnet: 172.18.10.0/24           podSubnet: 172.18.11.0/24
-Istio profile: default              Istio profile: default
 meshID: mesh1                       meshID: mesh1
 clusterName: cluster1               clusterName: cluster2
 network: network1                   network: network1
           ↕  cross-cluster remote secret (mesh.sh)
-          ↕  static pod-subnet routes (single network)
+          ↕  static pod-subnet routes → direct pod-to-pod
+```
+
+**c1c2-install-ewgw** (multi-network, traffic via east-west gateway)
+```
+c1 (kind-c1)                        c2 (kind-c2)
+podSubnet: 172.18.10.0/24           podSubnet: 172.18.11.0/24
+meshID: mesh1                       meshID: mesh1
+clusterName: cluster1               clusterName: cluster2
+network: network1                   network: network2
+          ↕  cross-cluster remote secret (mesh.sh)
+          ↕  cross-cluster traffic → east-west gateway:15443
 ```
 
 #### Verify Istio Mesh (c1/c2)
@@ -90,6 +101,47 @@ for i in $(seq 1 10); do
   kubectl --context kind-c2 exec -n istio-validation deploy/sleep -- curl -s helloworld.istio-validation.svc.cluster.local:5000/hello
 done
 ```
+
+#### Verify East-West Gateway — c1c2-install-ewgw only
+
+**1. Confirm Envoy routes c2 traffic through port 15443 (no installation required)**
+```bash
+kubectl --context kind-c1 exec -n istio-validation deploy/sleep -c istio-proxy -- \
+  curl -s localhost:15000/clusters | grep helloworld | grep -oE '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+:[0-9]+' | sort -u
+```
+Expected: one entry at `<pod-ip>:5000` (c1 local) and one at `<ewgw-ip>:15443` (c2 via east-west gateway).
+
+**2. tcpdump — Method A: install on kind node**
+
+Terminal 1 (start capture on c2 node):
+```bash
+docker exec c2-control-plane bash -c "apt-get update -qq && apt-get install -y tcpdump -qq"
+docker exec -it c2-control-plane tcpdump -i any port 15443 -nn
+```
+
+Terminal 2 (generate traffic):
+```bash
+for i in $(seq 1 20); do
+  kubectl --context kind-c1 exec -n istio-validation deploy/sleep -- \
+    curl -s helloworld.istio-validation.svc.cluster.local:5000/hello
+done
+```
+
+**3. tcpdump — Method B: kubectl debug node (no installation required)**
+```bash
+kubectl --context kind-c2 debug node/c2-control-plane \
+  -it --image=nicolaka/netshoot \
+  -- tcpdump -i any port 15443 -nn
+```
+
+Expected tcpdump output:
+```
+IP 172.18.10.x.xxxxx > 172.18.0.x.15443: Flags [S]    ← SYN (c1 pod → c2 ewgw)
+IP 172.18.0.x.15443 > 172.18.10.x.xxxxx: Flags [S.]   ← SYN-ACK
+IP 172.18.10.x.xxxxx > 172.18.0.x.15443: Flags [.]    ← ACK (mTLS handshake)
+```
+
+> **Note**: run tcpdump on **c2 node**, not c1 — the destination of cross-cluster traffic is c2's east-west gateway.
 
 #### Frequently used commands
 ```

--- a/config/config.env
+++ b/config/config.env
@@ -2,6 +2,8 @@ source ~/.bashrc
 
 export CTX_CLUSTER1=kind-c1
 export CTX_CLUSTER2=kind-c2
+export NETWORK_CLUSTER1=network1
+export NETWORK_CLUSTER2=network2
 
 kind_version=v0.26.0 # kind version : [ v0.14.0 , v0.23.0 , v0.26.0 ]
 istio_version=1.24.0  # istio vesion : [ 1.13.5 , 1.23.0 ,1.24.0]

--- a/config/config.env
+++ b/config/config.env
@@ -3,7 +3,7 @@ source ~/.bashrc
 export CTX_CLUSTER1=kind-c1
 export CTX_CLUSTER2=kind-c2
 export NETWORK_CLUSTER1=network1
-export NETWORK_CLUSTER2=network2
+export NETWORK_CLUSTER2=network1
 
 kind_version=v0.26.0 # kind version : [ v0.14.0 , v0.23.0 , v0.26.0 ]
 istio_version=1.24.0  # istio vesion : [ 1.13.5 , 1.23.0 ,1.24.0]

--- a/scripts/create_istio.sh
+++ b/scripts/create_istio.sh
@@ -30,7 +30,7 @@ istio(){
                 --from-file=cluster2/root-cert.pem \
                 --from-file=cluster2/cert-chain.pem
             echo $FILE_PATH_istio_2
-            envsubst '$istio_label' < $FILE_PATH_istio_2 | istioctl install --context="${CTX_CLUSTER2}" -y -f -
+            envsubst '$istio_label $NETWORK_CLUSTER2' < $FILE_PATH_istio_2 | istioctl install --context="${CTX_CLUSTER2}" -y -f -
             
         elif [[ "$cluster_mode" == "single" ]]; then
             # 單集群模式Istio

--- a/scripts/install_eastwestgateway.sh
+++ b/scripts/install_eastwestgateway.sh
@@ -7,20 +7,46 @@ source $abspath/config/config.env
 FILE_PATH_ewgw=$abspath/tools/istio/eastwestgateway/ewgw.yaml
 FILE_PATH_expose=$abspath/tools/istio/eastwestgateway/expose-services.yaml
 
+label_cluster(){
+    local ctx=$1
+    local network=$2
+
+    echo "Labeling nodes and istio-system namespace on ${ctx} with network=${network} ..."
+    kubectl --context="${ctx}" label node \
+        $(kubectl --context="${ctx}" get nodes -o jsonpath='{.items[*].metadata.name}') \
+        topology.istio.io/network=${network} --overwrite
+
+    kubectl --context="${ctx}" label namespace istio-system \
+        topology.istio.io/network=${network} --overwrite
+}
+
 install_eastwestgateway(){
     export PATH=$FOLDER_PATH_istio/bin:$PATH
 
+    label_cluster "${CTX_CLUSTER1}" "${NETWORK_CLUSTER1}"
+    label_cluster "${CTX_CLUSTER2}" "${NETWORK_CLUSTER2}"
+
     echo "Installing eastwestgateway on ${CTX_CLUSTER1} ..."
-    envsubst '$istio_label' < $FILE_PATH_ewgw | istioctl install --context="${CTX_CLUSTER1}" -y -f -
+    network_id=${NETWORK_CLUSTER1} envsubst '$istio_label $network_id' < $FILE_PATH_ewgw \
+        | istioctl install --context="${CTX_CLUSTER1}" -y -f -
 
     echo "Installing eastwestgateway on ${CTX_CLUSTER2} ..."
-    envsubst '$istio_label' < $FILE_PATH_ewgw | istioctl install --context="${CTX_CLUSTER2}" -y -f -
+    network_id=${NETWORK_CLUSTER2} envsubst '$istio_label $network_id' < $FILE_PATH_ewgw \
+        | istioctl install --context="${CTX_CLUSTER2}" -y -f -
 
     echo "Exposing services via cross-network-gateway on ${CTX_CLUSTER1} ..."
     kubectl --context="${CTX_CLUSTER1}" apply -f $FILE_PATH_expose
 
     echo "Exposing services via cross-network-gateway on ${CTX_CLUSTER2} ..."
     kubectl --context="${CTX_CLUSTER2}" apply -f $FILE_PATH_expose
+
+    echo "Restarting workloads to pick up network labels ..."
+    for ns in $(kubectl --context="${CTX_CLUSTER1}" get ns -o jsonpath='{.items[*].metadata.name}' | tr ' ' '\n' | grep -v "kube-\|istio-\|metallb"); do
+        kubectl --context="${CTX_CLUSTER1}" rollout restart deployment -n "$ns" 2>/dev/null || true
+    done
+    for ns in $(kubectl --context="${CTX_CLUSTER2}" get ns -o jsonpath='{.items[*].metadata.name}' | tr ' ' '\n' | grep -v "kube-\|istio-\|metallb"); do
+        kubectl --context="${CTX_CLUSTER2}" rollout restart deployment -n "$ns" 2>/dev/null || true
+    done
 
     echo "Eastwestgateway installation complete."
 }

--- a/scripts/install_eastwestgateway.sh
+++ b/scripts/install_eastwestgateway.sh
@@ -22,6 +22,13 @@ label_cluster(){
 
 install_eastwestgateway(){
     export PATH=$FOLDER_PATH_istio/bin:$PATH
+    export NETWORK_CLUSTER2=network2
+
+    echo "Reconfiguring istiod on ${CTX_CLUSTER2} for network=${NETWORK_CLUSTER2} ..."
+    envsubst '$istio_label $NETWORK_CLUSTER2' < $FILE_PATH_istio_2 \
+        | istioctl install --context="${CTX_CLUSTER2}" -y -f -
+    kubectl --context="${CTX_CLUSTER2}" -n istio-system \
+        rollout status deployment/istiod-${istio_label} --timeout=120s
 
     label_cluster "${CTX_CLUSTER1}" "${NETWORK_CLUSTER1}"
     label_cluster "${CTX_CLUSTER2}" "${NETWORK_CLUSTER2}"

--- a/tools/istio/certs/cluster2.yaml
+++ b/tools/istio/certs/cluster2.yaml
@@ -40,4 +40,4 @@ spec:
       meshID: mesh1
       multiCluster:
         clusterName: cluster2
-      network: network1
+      network: network2

--- a/tools/istio/certs/cluster2.yaml
+++ b/tools/istio/certs/cluster2.yaml
@@ -40,4 +40,4 @@ spec:
       meshID: mesh1
       multiCluster:
         clusterName: cluster2
-      network: network2
+      network: ${NETWORK_CLUSTER2}

--- a/tools/istio/eastwestgateway/ewgw.yaml
+++ b/tools/istio/eastwestgateway/ewgw.yaml
@@ -11,14 +11,14 @@ spec:
         label:
           istio: eastwestgateway
           app: istio-eastwestgateway
-          topology.istio.io/network: network1
+          topology.istio.io/network: ${network_id}
         enabled: true
         k8s:
           env:
             - name: ISTIO_META_ROUTER_MODE
               value: "sni-dnat"
             - name: ISTIO_META_REQUESTED_NETWORK_VIEW
-              value: network1
+              value: ${network_id}
           service:
             ports:
               - name: status-port
@@ -38,4 +38,4 @@ spec:
       istio-ingressgateway:
         injectionTemplate: gateway
     global:
-      network: network1
+      network: ${network_id}


### PR DESCRIPTION
## Summary

- **fix #25**: east-west gateway was being bypassed due to hardcoded `network1` on both clusters — fixed by per-cluster network label assignment
- **fix**: parameterize `NETWORK_CLUSTER2` so `c1c2-singlenet` remains unaffected
- **docs #27**: update README cluster architecture diagrams and add east-west gateway verification section

🤖 Generated with [Claude Code](https://claude.com/claude-code)