### PR TITLE
fix: use exact namespace matching to prevent istio-validation from being excluded in rollout restart

### DIFF
--- a/scripts/install_eastwestgateway.sh
+++ b/scripts/install_eastwestgateway.sh
@@ -48,10 +48,10 @@ install_eastwestgateway(){
     kubectl --context="${CTX_CLUSTER2}" apply -f $FILE_PATH_expose
 
     echo "Restarting workloads to pick up network labels ..."
-    for ns in $(kubectl --context="${CTX_CLUSTER1}" get ns -o jsonpath='{.items[*].metadata.name}' | tr ' ' '\n' | grep -v "kube-\|istio-\|metallb"); do
+    for ns in $(kubectl --context="${CTX_CLUSTER1}" get ns -o jsonpath='{.items[*].metadata.name}' | tr ' ' '\n' | grep -v "^kube-\|^istio-system$\|^metallb-system$"); do
         kubectl --context="${CTX_CLUSTER1}" rollout restart deployment -n "$ns" 2>/dev/null || true
     done
-    for ns in $(kubectl --context="${CTX_CLUSTER2}" get ns -o jsonpath='{.items[*].metadata.name}' | tr ' ' '\n' | grep -v "kube-\|istio-\|metallb"); do
+    for ns in $(kubectl --context="${CTX_CLUSTER2}" get ns -o jsonpath='{.items[*].metadata.name}' | tr ' ' '\n' | grep -v "^kube-\|^istio-system$\|^metallb-system$"); do
         kubectl --context="${CTX_CLUSTER2}" rollout restart deployment -n "$ns" 2>/dev/null || true
     done
 


### PR DESCRIPTION
## Summary

- `grep -v "kube-\|istio-\|metallb"` incorrectly matched `istio-validation`, preventing workloads from being restarted after network labels were applied
- c2 pods retained stale `topology.istio.io/network=network1` label, causing Envoy to route directly to pod IPs instead of through the eastwestgateway on port 15443
- Fixed by using exact namespace matching: `grep -v "^kube-\|^istio-system$\|^metallb-system$"`

## Test plan

- [ ] Run `make c1c2-install-ewgw`
- [ ] Verify `kubectl --context kind-c1 exec -n istio-validation deploy/sleep -c istio-proxy -- curl -s localhost:15000/clusters | grep helloworld | grep -oE '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+:[0-9]+' | sort -u` shows port 15443

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)