### PR TITLE
fix: handle missing kind and hardcoded /home/ben path

### DIFF
--- a/config/config.env
+++ b/config/config.env
@@ -29,4 +29,4 @@ FOLDER_PATH_kiali=$abspath/tools/kiali/helm-charts-$filtered_version_kiali/kiali
 FOLDER_PATH_samples=$abspath/samples
 FOLDER_PATH_metallb=$abspath/tools/metallb
 
-filter_kind_version=v$(kind --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+filter_kind_version=v$(kind --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || true)

--- a/scripts/create_cluster.sh
+++ b/scripts/create_cluster.sh
@@ -47,7 +47,7 @@ delete_kind_cluster(){
             done
             fi
         fi
-    sudo rm -rf /home/ben/.kind/etcd-c1 && mkdir -p /home/ben/.kind/etcd-c1
+    sudo rm -rf "$HOME/.kind/etcd-c1" && mkdir -p "$HOME/.kind/etcd-c1"
     echo "end delete_kind_cluster() .."
 }
 
@@ -67,10 +67,10 @@ build_kind_config(){
     cp "$base_config" "$tmp_config"
     # extraMounts on /var/lib/etcd only works on kind v0.26.0+
     if [[ "$kind_version" == "v0.26.0" ]]; then
-        mkdir -p /home/ben/.kind/etcd-c1
-        cat >> "$tmp_config" << 'EOF'
+        mkdir -p "$HOME/.kind/etcd-c1"
+        cat >> "$tmp_config" << EOF
     extraMounts:
-      - hostPath: /home/ben/.kind/etcd-c1
+      - hostPath: $HOME/.kind/etcd-c1
         containerPath: /var/lib/etcd
 EOF
     fi


### PR DESCRIPTION
## Summary

- `config/config.env`: 在 `filter_kind_version` pipeline 加上 `|| true`，避免 `kind` 未安裝時 bash `set -e` 提前退出
- `scripts/create_cluster.sh`: 將硬編碼的 `/home/ben` 替換為 `$HOME`，並將 heredoc `'EOF'` 改為 `EOF` 使變數可展開

## Test plan

- [ ] 在 `kind` 未安裝的環境下執行 `make c1-sidecar`，確認不再提前退出
- [ ] 以非 `ben` 的使用者身份執行，確認 `.kind/etcd-c1` 路徑正確建立

Closes #38