### PR TITLE
feat: upgrade to kind v0.30.0 / Kubernetes 1.34 / Istio 1.29.2

### DIFF
--- a/config/config.env
+++ b/config/config.env
@@ -5,9 +5,9 @@ export CTX_CLUSTER2=kind-c2
 export NETWORK_CLUSTER1=network1
 export NETWORK_CLUSTER2=network1
 
-kind_version=v0.26.0 # kind version : [ v0.14.0 , v0.23.0 , v0.26.0 ]
-istio_version=1.24.0  # istio vesion : [ 1.13.5 , 1.23.0 ,1.24.0]
-export istio_label=1-24-0  # istio vesion : [ 1-13-5 , 1-23-0 ,1-24-0]
+kind_version=v0.30.0 # kind version : [ v0.14.0 , v0.23.0 , v0.26.0 , v0.30.0 ]
+istio_version=1.29.2  # istio vesion : [ 1.13.5 , 1.23.0 ,1.24.0 ,1.29.2]
+export istio_label=1-29-2  # istio vesion : [ 1-13-5 , 1-23-0 ,1-24-0 ,1-29-2]
 kiali_version=v1.49.0 # kiali version: [ v1.49.0 , v1.87.0 , v2.0.0]
 
 cluster_mode=multi

--- a/scripts/create_cluster.sh
+++ b/scripts/create_cluster.sh
@@ -56,6 +56,7 @@ get_node_image(){
         v0.14.0) echo "kindest/node:v1.24.0" ;;
         v0.23.0) echo "kindest/node:v1.27.3" ;;
         v0.26.0) echo "kindest/node:v1.29.2" ;;
+        v0.30.0) echo "kindest/node:v1.34.0" ;;
         *) echo "" ;;
     esac
 }


### PR DESCRIPTION
## Summary

- `config/config.env`: 升級 `kind_version` → v0.30.0、`istio_version` → 1.29.2、`istio_label` → 1-29-2
- `scripts/create_cluster.sh`: `get_node_image()` 新增 v0.30.0 → `kindest/node:v1.34.0` 對應

## Test Result

本地執行 `make c1-sidecar` 測試通過：

```
✔ istiod-1-29-2        Running
✔ istio-ingressgateway Running
✔ helloworld-v1        2/2 Running（sidecar 注入正常）
✔ sleep                2/2 Running
```

Closes #47