### PR TITLE
chore: sync 1-feat-develop changes to main

### DIFF
--- a/config/config.env
+++ b/config/config.env
@@ -9,6 +9,7 @@ kind_version=v0.30.0 # kind version : [ v0.14.0 , v0.23.0 , v0.26.0 , v0.30.0 ]
 istio_version=1.29.2  # istio vesion : [ 1.13.5 , 1.23.0 ,1.24.0 ,1.29.2]
 export istio_label=1-29-2  # istio vesion : [ 1-13-5 , 1-23-0 ,1-24-0 ,1-29-2]
 kiali_version=v1.49.0 # kiali version: [ v1.49.0 , v1.87.0 , v2.0.0]
+kubectl_version=v1.34.8 # 對齊 k8s v1.34（kind node image v1.34.0）
 
 cluster_mode=multi
 
@@ -31,3 +32,4 @@ FOLDER_PATH_samples=$abspath/samples
 FOLDER_PATH_metallb=$abspath/tools/metallb
 
 filter_kind_version=v$(kind --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || true)
+filter_kubectl_version=$(kubectl version --client 2>/dev/null | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)

--- a/scripts/create_cluster.sh
+++ b/scripts/create_cluster.sh
@@ -26,9 +26,17 @@ pretask(){
     # download kind
     if [ "$filter_kind_version" != "$kind_version" ]; then
         echo "start kind download"
-        [ $(uname -m) = x86_64 ] && curl -Lo ./kind https://kind.sigs.k8s.io/dl/$kind_version/kind-linux-amd64    
+        [ $(uname -m) = x86_64 ] && curl -Lo ./kind https://kind.sigs.k8s.io/dl/$kind_version/kind-linux-amd64
         chmod +x ./kind
         sudo mv ./kind /usr/local/bin/kind
+    fi
+
+    # download kubectl
+    if [ "$filter_kubectl_version" != "$kubectl_version" ]; then
+        echo "start kubectl download"
+        [ $(uname -m) = x86_64 ] && curl -Lo ./kubectl "https://dl.k8s.io/release/$kubectl_version/bin/linux/amd64/kubectl"
+        chmod +x ./kubectl
+        sudo mv ./kubectl /usr/local/bin/kubectl
     fi
     echo "end pretask() .."
 }


### PR DESCRIPTION
Sync kubectl auto-download into main.

pretask 比照 kind 邏輯，在 kubectl 缺席或版本不符時自動下載 v1.34.8，讓新環境 `make` 一鍵可跑。

Closes #62