### PR TITLE
chore: remove unused FOLDER_PATH_operator variable from config.env

### DIFF
--- a/config/config.env
+++ b/config/config.env
@@ -23,7 +23,6 @@ FILE_PATH_prometheus=/tmp/download/istio-$istio_version/samples/addons/prometheu
 
 FOLDER_PATH_download=/tmp/download
 FOLDER_PATH_istio=/tmp/download/istio-$istio_version
-FOLDER_PATH_operator=$abspath/tools/istio/operator
 FOLDER_PATH_cacerts=/tmp/download/certs
 FOLDER_PATH_kiali=$abspath/tools/kiali/helm-charts-$filtered_version_kiali/kiali-operator
 FOLDER_PATH_samples=$abspath/samples


### PR DESCRIPTION
## 內容
移除 `config/config.env` 的死變數 `FOLDER_PATH_operator`(僅一行)。

全 repo 無任何引用 — 前身 `FOLDER_PATH_certs` 僅被 `create_cluster.sh` 的 `istio()` 死碼使用(#68 已移除),#70 改名時保留了已成死變數的它。

## 驗證
- `grep -rn FOLDER_PATH_operator` 確認除定義行外無引用
- `bash -n config/config.env` 通過

Closes #73