### PR TITLE
chore: sync removal of unused FOLDER_PATH_operator to main

### DIFF
--- a/config/config.env
+++ b/config/config.env
@@ -23,7 +23,6 @@ FILE_PATH_prometheus=/tmp/download/istio-$istio_version/samples/addons/prometheu
 
 FOLDER_PATH_download=/tmp/download
 FOLDER_PATH_istio=/tmp/download/istio-$istio_version
-FOLDER_PATH_operator=$abspath/tools/istio/operator
 FOLDER_PATH_cacerts=/tmp/download/certs
 FOLDER_PATH_kiali=$abspath/tools/kiali/helm-charts-$filtered_version_kiali/kiali-operator
 FOLDER_PATH_samples=$abspath/samples


### PR DESCRIPTION
Sync PR #74 (remove unused FOLDER_PATH_operator from config.env) to main.

Closes #73