### PR TITLE
test: remove holdApplicationUntilProxyStarts and enable native sidecar for Istio 1.29+

### DIFF
--- a/config/config.env
+++ b/config/config.env
@@ -16,8 +16,17 @@ filtered_version_kiali=$(echo "$kiali_version" | tr -d 'v')
 
 FILE_PATH_kind=$abspath/tools/kind/kind-c1.yaml
 FILE_PATH_kind_2=$abspath/tools/kind/kind-c2.yaml
-FILE_PATH_istio=$abspath/tools/istio/operator/cluster1.yaml
-FILE_PATH_istio_2=$abspath/tools/istio/operator/cluster2.yaml
+# Istio operator 設定依版本選檔：
+#   1.29+   → cluster1.yaml / cluster2.yaml（移除 holdApplicationUntilProxyStarts、啟用 native sidecar）
+#   1.29 以下 → cluster1-legacy.yaml / cluster2-legacy.yaml（維持 holdApplicationUntilProxyStarts: true，無 native sidecar）
+istio_minor="${istio_version%.*}"   # 1.29.2 -> 1.29
+if [ "$(printf '%s\n%s\n' "$istio_minor" 1.29 | sort -V | tail -1)" = "$istio_minor" ]; then
+    FILE_PATH_istio=$abspath/tools/istio/operator/cluster1.yaml
+    FILE_PATH_istio_2=$abspath/tools/istio/operator/cluster2.yaml
+else
+    FILE_PATH_istio=$abspath/tools/istio/operator/cluster1-legacy.yaml
+    FILE_PATH_istio_2=$abspath/tools/istio/operator/cluster2-legacy.yaml
+fi
 FILE_PATH_kiali=$abspath/tools/kiali/helm-charts-$filtered_version_kiali/kiali-operator/values.yaml
 FILE_PATH_prometheus=/tmp/download/istio-$istio_version/samples/addons/prometheus.yaml
 

--- a/tools/istio/operator/cluster1-legacy.yaml
+++ b/tools/istio/operator/cluster1-legacy.yaml
@@ -5,6 +5,8 @@ spec:
   revision: ${istio_label}
   meshConfig:
     accessLogFile: /dev/stdout
+    defaultConfig:
+      holdApplicationUntilProxyStarts: true
   components:
     ingressGateways:
     - enabled: true
@@ -19,10 +21,6 @@ spec:
           - name: PILOT_FILTER_GATEWAY_CLUSTER_CONFIG
             value: "true"
           - name: PILOT_HTTP10
-            value: "true"
-          # Istio 1.29+：改用 native sidecar（init container, restartPolicy: Always），
-          # 取代 meshConfig.defaultConfig.holdApplicationUntilProxyStarts
-          - name: ENABLE_NATIVE_SIDECARS
             value: "true"
         overlays:
         - apiVersion: apps/v1

--- a/tools/istio/operator/cluster2-legacy.yaml
+++ b/tools/istio/operator/cluster2-legacy.yaml
@@ -5,6 +5,8 @@ spec:
   revision: ${istio_label}
   meshConfig:
     accessLogFile: /dev/stdout
+    defaultConfig:
+      holdApplicationUntilProxyStarts: true
   components:
     ingressGateways:
     - enabled: true
@@ -19,10 +21,6 @@ spec:
           - name: PILOT_FILTER_GATEWAY_CLUSTER_CONFIG
             value: "true"
           - name: PILOT_HTTP10
-            value: "true"
-          # Istio 1.29+：改用 native sidecar（init container, restartPolicy: Always），
-          # 取代 meshConfig.defaultConfig.holdApplicationUntilProxyStarts
-          - name: ENABLE_NATIVE_SIDECARS
             value: "true"
         overlays:
         - apiVersion: apps/v1
@@ -41,5 +39,5 @@ spec:
       variant: debug
       meshID: mesh1
       multiCluster:
-        clusterName: cluster1
-      network: network1
+        clusterName: cluster2
+      network: ${NETWORK_CLUSTER2}

--- a/tools/istio/operator/cluster2.yaml
+++ b/tools/istio/operator/cluster2.yaml
@@ -5,8 +5,6 @@ spec:
   revision: ${istio_label}
   meshConfig:
     accessLogFile: /dev/stdout
-    defaultConfig:
-      holdApplicationUntilProxyStarts: true
   components:
     ingressGateways:
     - enabled: true
@@ -21,6 +19,10 @@ spec:
           - name: PILOT_FILTER_GATEWAY_CLUSTER_CONFIG
             value: "true"
           - name: PILOT_HTTP10
+            value: "true"
+          # Istio 1.29+：改用 native sidecar（init container, restartPolicy: Always），
+          # 取代 meshConfig.defaultConfig.holdApplicationUntilProxyStarts
+          - name: ENABLE_NATIVE_SIDECARS
             value: "true"
         overlays:
         - apiVersion: apps/v1


### PR DESCRIPTION
## 摘要

針對 Istio 1.29+ 移除 `holdApplicationUntilProxyStarts`、改用 native sidecar；1.29 以下維持原行為。

## 做法

採「新增 legacy 檔 + config.env 依版本選檔」方案（最單純、零新依賴、與 repo 既有 `istio_consistent_hash.sh` 慣例一致）：

- `cluster1.yaml` / `cluster2.yaml` → **1.29+ 版**：移除 `meshConfig.defaultConfig.holdApplicationUntilProxyStarts`，pilot env 加入 `ENABLE_NATIVE_SIDECARS=true`。
- 新增 `cluster1-legacy.yaml` / `cluster2-legacy.yaml` → **<1.29 版**：保留 `hold: true`、無 native（即原檔）。
- `config/config.env` → 以 `1.29` 為門檻（`sort -V`）選用主檔或 legacy 檔；`create_istio.sh` 無需更動。

## 驗證

- 版本門檻判斷逐版測試：1.13.5 / 1.23.0 / 1.24.0 / 1.28.9 → legacy；1.29.0 / 1.29.2 / 1.30.1 / 1.31.0 → 主檔。
- 四份 YAML 經 `envsubst` 渲染後皆通過 `yaml.safe_load`。
- 主檔已無 `holdApplicationUntilProxyStarts`（僅註解）、含 `ENABLE_NATIVE_SIDECARS`；legacy 檔維持 `hold: true`。
- ⏳ 待人工驗證：`make c1c2-singlenet` 安裝流程、1.29+ sidecar 以 native（init container）注入。

Closes #76
