### PR TITLE
feat: decouple k8s node image from kind version and document istio/k8s/kind matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,23 @@ kind-create-cluster/
    | Istio | 1.29.2 | 1.31 – 1.35 |
    | Kiali | v1.49.0 | — |
 
+   **Version matrix — Istio ↔ Kubernetes ↔ node image**
+
+   `kind_version` only selects the kind **binary**; the cluster Kubernetes version is
+   chosen independently via `node_image` in `config/config.env` (leave empty to fall
+   back to the `kind_version` default image). The `node_image` must be one that the
+   installed kind binary supports — kind v0.30.0 ships `v1.34.0` / `v1.33.4` /
+   `v1.32.8` / `v1.31.12`. Pick a Kubernetes version inside the target Istio's
+   [supported range](https://istio.io/latest/docs/releases/supported-releases/):
+
+   | Istio | Supported K8s | Recommended `node_image` (kind v0.30.0) |
+   |---|---|---|
+   | 1.29.2 | 1.31 – 1.35 | `kindest/node:v1.34.0` |
+   | 1.24.0 | 1.28 – 1.31 | `kindest/node:v1.31.12` |
+
+   > Also align `kubectl_version` with the chosen Kubernetes version (version skew
+   > generally tolerates ±1 minor).
+
 2. **Run via Makefile** (recommended)
 
    | Command | Description |

--- a/config/config.env
+++ b/config/config.env
@@ -3,11 +3,16 @@ export CTX_CLUSTER2=kind-c2
 export NETWORK_CLUSTER1=network1
 export NETWORK_CLUSTER2=network1
 
-kind_version=v0.30.0 # kind version : [ v0.14.0 , v0.23.0 , v0.26.0 , v0.30.0 ]
+kind_version=v0.30.0 # kind binary 版本 : [ v0.14.0 , v0.23.0 , v0.26.0 , v0.30.0 ]
 istio_version=1.29.2  # istio vesion : [ 1.13.5 , 1.23.0 ,1.24.0 ,1.29.2]
 export istio_label=1-29-2  # istio vesion : [ 1-13-5 , 1-23-0 ,1-24-0 ,1-29-2]
+# k8s node image：決定叢集 K8s 版本，與 kind binary 及 istio_version 各自獨立。
+# 須為 kind_version 所支援的 image；留空則 fall back 至 kind_version 對應的預設 image。
+# kind v0.30.0 支援：v1.34.0 / v1.33.4 / v1.32.8 / v1.31.12
+# 版本對照（Istio ↔ 支援 K8s）詳見 README.md 版本對照表。
+node_image="kindest/node:v1.34.0@sha256:7416a61b42b1662ca6ca89f02028ac133a309a2a30ba309614e8ec94d976dc5a"
 kiali_version=v1.49.0 # kiali version: [ v1.49.0 ]（僅 vendored 此版，其餘版本已移除）
-kubectl_version=v1.34.8 # 對齊 k8s v1.34（kind node image v1.34.0）
+kubectl_version=v1.34.8 # 建議對齊 node_image 的 K8s 版本（目前 v1.34 ↔ node v1.34.0）；version skew 一般容許 ±1 minor
 
 cluster_mode=multi
 

--- a/scripts/create_cluster.sh
+++ b/scripts/create_cluster.sh
@@ -60,6 +60,14 @@ delete_kind_cluster(){
 }
 
 get_node_image(){
+    # 若 config.env 明確指定 node_image，優先使用（k8s 版本與 kind binary 解耦）。
+    # 同一個 kind binary 可支援多個 node image，例如 kind v0.30.0 支援
+    # v1.34.0 / v1.33.4 / v1.32.8 / v1.31.12。
+    if [[ -n "$node_image" ]]; then
+        echo "$node_image"
+        return
+    fi
+    # 未指定時 fall back 回 kind_version 對應的預設 node image。
     case "$kind_version" in
         v0.14.0) echo "kindest/node:v1.24.0" ;;
         v0.23.0) echo "kindest/node:v1.27.3" ;;
@@ -88,9 +96,9 @@ EOF
 
 create_kind_cluster(){
     echo "start create_kind_cluster() .."
-    local node_image=$(get_node_image)
+    local resolved_image=$(get_node_image)
     local image_flag=""
-    [[ -n "$node_image" ]] && image_flag="--image=$node_image"
+    [[ -n "$resolved_image" ]] && image_flag="--image=$resolved_image"
 
     if [[ "$cluster_mode" == "multi" ]]; then
         echo "創建集群 c1 和 c2"


### PR DESCRIPTION
## 摘要

把「叢集 K8s 版本」從「kind binary 版本」解耦，讓同一個 kind binary 可選用其支援的不同 K8s node image，以落在目標 Istio 的支援矩陣內，並補上版本對照表。

## 動機

測試 Istio 1.24（#76 legacy 路徑）時發現：`get_node_image()` 以 `kind_version` 為唯一 key（`v0.30.0 → 1.34` 寫死），導致無法在 kind v0.30.0 下選用 Istio 1.24 支援的 K8s 1.31。但 kind v0.30.0 binary 其實同時支援 `v1.34.0 / v1.33.4 / v1.32.8 / v1.31.12`。

## 變更

- **`config/config.env`**：新增 `node_image`（預設 `v1.34.0`，digest-pinned）；留空則 fall back kind_version 對應表。`kubectl_version` 加上對齊註記。
- **`scripts/create_cluster.sh`**：`get_node_image()` 優先回傳 `$node_image`；`create_kind_cluster` 內同名 local 改名 `resolved_image` 避免遮蔽。
- **`README.md`**：新增 Istio ↔ 支援 K8s ↔ 建議 node image 對照表。

## 驗證

- ✅ get_node_image() 三情境：指定 node_image / 留空 fall back / 1.31 覆蓋。
- ✅ 預設（istio 1.29.2 + node v1.34.0）`make c1c2-singlenet` 不退化。
- ✅ istio 1.24.0 + node **v1.31.12**（支援矩陣內）：
  - K8s 節點版本 = v1.31.12、istiod = 1-24-0
  - legacy 行為：`holdApplicationUntilProxyStarts: true`、istio-proxy 為一般 container、**無** `ENABLE_NATIVE_SIDECARS`
  - mesh 跨叢集連通正常

Closes #79
