### PR TITLE
chore: sync 1-feat-develop changes to main (#76, #79)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,23 @@ kind-create-cluster/
    | Istio | 1.29.2 | 1.31 – 1.35 |
    | Kiali | v1.49.0 | — |
 
+   **Version matrix — Istio ↔ Kubernetes ↔ node image**
+
+   `kind_version` only selects the kind **binary**; the cluster Kubernetes version is
+   chosen independently via `node_image` in `config/config.env` (leave empty to fall
+   back to the `kind_version` default image). The `node_image` must be one that the
+   installed kind binary supports — kind v0.30.0 ships `v1.34.0` / `v1.33.4` /
+   `v1.32.8` / `v1.31.12`. Pick a Kubernetes version inside the target Istio's
+   [supported range](https://istio.io/latest/docs/releases/supported-releases/):
+
+   | Istio | Supported K8s | Recommended `node_image` (kind v0.30.0) |
+   |---|---|---|
+   | 1.29.2 | 1.31 – 1.35 | `kindest/node:v1.34.0` |
+   | 1.24.0 | 1.28 – 1.31 | `kindest/node:v1.31.12` |
+
+   > Also align `kubectl_version` with the chosen Kubernetes version (version skew
+   > generally tolerates ±1 minor).
+
 2. **Run via Makefile** (recommended)
 
    | Command | Description |

--- a/config/config.env
+++ b/config/config.env
@@ -16,8 +16,17 @@ filtered_version_kiali=$(echo "$kiali_version" | tr -d 'v')
 
 FILE_PATH_kind=$abspath/tools/kind/kind-c1.yaml
 FILE_PATH_kind_2=$abspath/tools/kind/kind-c2.yaml
-FILE_PATH_istio=$abspath/tools/istio/operator/cluster1.yaml
-FILE_PATH_istio_2=$abspath/tools/istio/operator/cluster2.yaml
+# Istio operator 設定依版本選檔：
+#   1.29+   → cluster1.yaml / cluster2.yaml（移除 holdApplicationUntilProxyStarts、啟用 native sidecar）
+#   1.29 以下 → cluster1-legacy.yaml / cluster2-legacy.yaml（維持 holdApplicationUntilProxyStarts: true，無 native sidecar）
+istio_minor="${istio_version%.*}"   # 1.29.2 -> 1.29
+if [ "$(printf '%s\n%s\n' "$istio_minor" 1.29 | sort -V | tail -1)" = "$istio_minor" ]; then
+    FILE_PATH_istio=$abspath/tools/istio/operator/cluster1.yaml
+    FILE_PATH_istio_2=$abspath/tools/istio/operator/cluster2.yaml
+else
+    FILE_PATH_istio=$abspath/tools/istio/operator/cluster1-legacy.yaml
+    FILE_PATH_istio_2=$abspath/tools/istio/operator/cluster2-legacy.yaml
+fi
 FILE_PATH_kiali=$abspath/tools/kiali/helm-charts-$filtered_version_kiali/kiali-operator/values.yaml
 FILE_PATH_prometheus=/tmp/download/istio-$istio_version/samples/addons/prometheus.yaml
 

--- a/config/config.env
+++ b/config/config.env
@@ -3,11 +3,16 @@ export CTX_CLUSTER2=kind-c2
 export NETWORK_CLUSTER1=network1
 export NETWORK_CLUSTER2=network1
 
-kind_version=v0.30.0 # kind version : [ v0.14.0 , v0.23.0 , v0.26.0 , v0.30.0 ]
+kind_version=v0.30.0 # kind binary 版本 : [ v0.14.0 , v0.23.0 , v0.26.0 , v0.30.0 ]
 istio_version=1.29.2  # istio vesion : [ 1.13.5 , 1.23.0 ,1.24.0 ,1.29.2]
 export istio_label=1-29-2  # istio vesion : [ 1-13-5 , 1-23-0 ,1-24-0 ,1-29-2]
+# k8s node image：決定叢集 K8s 版本，與 kind binary 及 istio_version 各自獨立。
+# 須為 kind_version 所支援的 image；留空則 fall back 至 kind_version 對應的預設 image。
+# kind v0.30.0 支援：v1.34.0 / v1.33.4 / v1.32.8 / v1.31.12
+# 版本對照（Istio ↔ 支援 K8s）詳見 README.md 版本對照表。
+node_image="kindest/node:v1.34.0@sha256:7416a61b42b1662ca6ca89f02028ac133a309a2a30ba309614e8ec94d976dc5a"
 kiali_version=v1.49.0 # kiali version: [ v1.49.0 ]（僅 vendored 此版，其餘版本已移除）
-kubectl_version=v1.34.8 # 對齊 k8s v1.34（kind node image v1.34.0）
+kubectl_version=v1.34.8 # 建議對齊 node_image 的 K8s 版本（目前 v1.34 ↔ node v1.34.0）；version skew 一般容許 ±1 minor
 
 cluster_mode=multi
 

--- a/scripts/create_cluster.sh
+++ b/scripts/create_cluster.sh
@@ -60,6 +60,14 @@ delete_kind_cluster(){
 }
 
 get_node_image(){
+    # 若 config.env 明確指定 node_image，優先使用（k8s 版本與 kind binary 解耦）。
+    # 同一個 kind binary 可支援多個 node image，例如 kind v0.30.0 支援
+    # v1.34.0 / v1.33.4 / v1.32.8 / v1.31.12。
+    if [[ -n "$node_image" ]]; then
+        echo "$node_image"
+        return
+    fi
+    # 未指定時 fall back 回 kind_version 對應的預設 node image。
     case "$kind_version" in
         v0.14.0) echo "kindest/node:v1.24.0" ;;
         v0.23.0) echo "kindest/node:v1.27.3" ;;
@@ -88,9 +96,9 @@ EOF
 
 create_kind_cluster(){
     echo "start create_kind_cluster() .."
-    local node_image=$(get_node_image)
+    local resolved_image=$(get_node_image)
     local image_flag=""
-    [[ -n "$node_image" ]] && image_flag="--image=$node_image"
+    [[ -n "$resolved_image" ]] && image_flag="--image=$resolved_image"
 
     if [[ "$cluster_mode" == "multi" ]]; then
         echo "創建集群 c1 和 c2"

--- a/tools/istio/operator/cluster1-legacy.yaml
+++ b/tools/istio/operator/cluster1-legacy.yaml
@@ -5,6 +5,8 @@ spec:
   revision: ${istio_label}
   meshConfig:
     accessLogFile: /dev/stdout
+    defaultConfig:
+      holdApplicationUntilProxyStarts: true
   components:
     ingressGateways:
     - enabled: true
@@ -19,10 +21,6 @@ spec:
           - name: PILOT_FILTER_GATEWAY_CLUSTER_CONFIG
             value: "true"
           - name: PILOT_HTTP10
-            value: "true"
-          # Istio 1.29+：改用 native sidecar（init container, restartPolicy: Always），
-          # 取代 meshConfig.defaultConfig.holdApplicationUntilProxyStarts
-          - name: ENABLE_NATIVE_SIDECARS
             value: "true"
         overlays:
         - apiVersion: apps/v1

--- a/tools/istio/operator/cluster2-legacy.yaml
+++ b/tools/istio/operator/cluster2-legacy.yaml
@@ -5,6 +5,8 @@ spec:
   revision: ${istio_label}
   meshConfig:
     accessLogFile: /dev/stdout
+    defaultConfig:
+      holdApplicationUntilProxyStarts: true
   components:
     ingressGateways:
     - enabled: true
@@ -19,10 +21,6 @@ spec:
           - name: PILOT_FILTER_GATEWAY_CLUSTER_CONFIG
             value: "true"
           - name: PILOT_HTTP10
-            value: "true"
-          # Istio 1.29+：改用 native sidecar（init container, restartPolicy: Always），
-          # 取代 meshConfig.defaultConfig.holdApplicationUntilProxyStarts
-          - name: ENABLE_NATIVE_SIDECARS
             value: "true"
         overlays:
         - apiVersion: apps/v1
@@ -41,5 +39,5 @@ spec:
       variant: debug
       meshID: mesh1
       multiCluster:
-        clusterName: cluster1
-      network: network1
+        clusterName: cluster2
+      network: ${NETWORK_CLUSTER2}

--- a/tools/istio/operator/cluster2.yaml
+++ b/tools/istio/operator/cluster2.yaml
@@ -5,8 +5,6 @@ spec:
   revision: ${istio_label}
   meshConfig:
     accessLogFile: /dev/stdout
-    defaultConfig:
-      holdApplicationUntilProxyStarts: true
   components:
     ingressGateways:
     - enabled: true
@@ -21,6 +19,10 @@ spec:
           - name: PILOT_FILTER_GATEWAY_CLUSTER_CONFIG
             value: "true"
           - name: PILOT_HTTP10
+            value: "true"
+          # Istio 1.29+：改用 native sidecar（init container, restartPolicy: Always），
+          # 取代 meshConfig.defaultConfig.holdApplicationUntilProxyStarts
+          - name: ENABLE_NATIVE_SIDECARS
             value: "true"
         overlays:
         - apiVersion: apps/v1


### PR DESCRIPTION
Sync `1-feat-develop` 變更進 `main`。

包含：
- #76：Istio 1.29+ 移除 holdApplicationUntilProxyStarts、改用 native sidecar；新增 cluster*-legacy.yaml 供 <1.29 使用，config.env 依版本選檔
- #79：解耦 k8s node image 與 kind binary 版本（config.env 新增 node_image）、README 新增 Istio↔K8s↔node image 版本對照表

兩者均經 make c1c2-singlenet 實機驗證（native sidecar、legacy 行為、mesh 跨叢集連通）。

Closes #76
Closes #79
