### PR TITLE
chore: bump Istio default to 1.29.4 and verify single/multi/ewgw

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ issue → feature branch → commit → PR → merge to 1-feat-develop → sync 
 | Component | Version | Kubernetes |
 |-----------|---------|------------|
 | kind | v0.30.0 | v1.34.0 |
-| Istio | 1.29.2 | 1.31–1.35 |
+| Istio | 1.29.4 | 1.31–1.35 |
 | Kiali | v1.49.0 | — |
 
 版本設定檔：`config/config.env`

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ kind-create-cluster/
    | Component | Version | Kubernetes |
    |---|---|---|
    | kind | v0.30.0 | v1.34.0 |
-   | Istio | 1.29.2 | 1.31 – 1.35 |
+   | Istio | 1.29.4 | 1.31 – 1.35 |
    | Kiali | v1.49.0 | — |
 
    **Version matrix — how `kind_version` / `node_image` / `istio_version` / `kubectl_version` fit together**
@@ -40,15 +40,15 @@ kind-create-cluster/
      table below).
    - `node_image`'s Kubernetes version must sit inside the target Istio's
      [supported range](https://istio.io/latest/docs/releases/supported-releases/).
-   - `istio_label` **must equal** `istio_version` (dots → dashes, e.g. `1.29.2` →
-     `1-29-2`); always change the two together.
+   - `istio_label` **must equal** `istio_version` (dots → dashes, e.g. `1.29.4` →
+     `1-29-4`); always change the two together.
    - `kubectl_version` should track `node_image`'s Kubernetes minor (skew tolerates ±1).
 
    Vetted combinations (all on kind v0.30.0):
 
    | kind_version | istio_version | istio_label | node_image (K8s) | Istio-supported K8s | kubectl_version |
    |---|---|---|---|---|---|
-   | v0.30.0 | 1.29.2 | 1-29-2 | `kindest/node:v1.34.0` | 1.31 – 1.35 | v1.34.8 |
+   | v0.30.0 | 1.29.4 | 1-29-4 | `kindest/node:v1.34.0` | 1.31 – 1.35 | v1.34.8 |
    | v0.30.0 | 1.24.0 | 1-24-0 | `kindest/node:v1.31.12` | 1.28 – 1.31 | v1.31.x |
 
    Fall-back default `node_image` when `node_image` is left empty (`scripts/create_cluster.sh`):
@@ -301,10 +301,10 @@ kubectl --context kind-c2 rollout restart deployment/istio-eastwestgateway -n is
 ```
 # kind version is defined in config/config.env (kind_version)
 [ $(uname -m) = x86_64 ] && curl -Lo ./kind https://kind.sigs.k8s.io/dl/${kind_version}/kind-linux-amd64
-wget "https://github.com/istio/istio/releases/download/1.29.2/istio-1.29.2-linux-amd64.tar.gz" -O - | tar -xz 
+wget "https://github.com/istio/istio/releases/download/1.29.4/istio-1.29.4-linux-amd64.tar.gz" -O - | tar -xz 
 cp tools/istio/operator/cluster.yaml  .
 # 統一檔需帶入 cluster 差異參數再 envsubst（c1 範例：cluster1 / network1）
-istio_label=1-29-2 CLUSTER_NAME=cluster1 NETWORK_NAME=network1 \
+istio_label=1-29-4 CLUSTER_NAME=cluster1 NETWORK_NAME=network1 \
   envsubst '$istio_label $CLUSTER_NAME $NETWORK_NAME' < cluster.yaml | istioctl install -y -f -
 
 ```

--- a/config/config.env
+++ b/config/config.env
@@ -4,8 +4,8 @@ export NETWORK_CLUSTER1=network1
 export NETWORK_CLUSTER2=network1
 
 kind_version=v0.30.0 # kind binary 版本 : [ v0.14.0 , v0.23.0 , v0.26.0 , v0.30.0 ]
-istio_version=1.29.2  # istio vesion : [ 1.13.5 , 1.23.0 ,1.24.0 ,1.29.2]
-export istio_label=1-29-2  # istio vesion : [ 1-13-5 , 1-23-0 ,1-24-0 ,1-29-2]
+istio_version=1.29.4  # istio vesion : [ 1.13.5 , 1.23.0 ,1.24.0 ,1.29.2 ,1.29.4]
+export istio_label=1-29-4  # istio vesion : [ 1-13-5 , 1-23-0 ,1-24-0 ,1-29-2 ,1-29-4]
 # k8s node image：決定叢集 K8s 版本，與 kind binary 及 istio_version 各自獨立。
 # 須為 kind_version 所支援的 image；留空則 fall back 至 kind_version 對應的預設 image。
 # kind v0.30.0 支援：v1.34.0 / v1.33.4 / v1.32.8 / v1.31.12
@@ -25,7 +25,7 @@ FILE_PATH_kind_2=$abspath/tools/kind/kind-c2.yaml
 # cluster 差異由腳本以 envsubst 帶入 ${CLUSTER_NAME} / ${NETWORK_NAME}）：
 #   1.29+   → cluster.yaml（移除 holdApplicationUntilProxyStarts、啟用 native sidecar）
 #   1.29 以下 → cluster-legacy.yaml（維持 holdApplicationUntilProxyStarts: true，無 native sidecar）
-istio_minor="${istio_version%.*}"   # 1.29.2 -> 1.29
+istio_minor="${istio_version%.*}"   # 1.29.4 -> 1.29
 if [ "$(printf '%s\n%s\n' "$istio_minor" 1.29 | sort -V | tail -1)" = "$istio_minor" ]; then
     FILE_PATH_istio=$abspath/tools/istio/operator/cluster.yaml
 else


### PR DESCRIPTION
## 概述

將專案預設 Istio 版本從 `1.29.2` bump 到 `1.29.4`（同 minor patch，仍走 `cluster.yaml` native sidecar 路徑，K8s 相容範圍 1.31–1.35 與 node `v1.34.0` 不變）。

## 變更

- `config/config.env`：`istio_version=1.29.4` / `istio_label=1-29-4`，選項清單加入 1.29.4
- `README.md`：版本表與 vetted 組合表 1.29.2 → 1.29.4；manual install 的 wget URL 與 `istio_label` 同步
- `CLAUDE.md`：版本資訊表 Istio 1.29.2 → 1.29.4

## 驗證（實機，node v1.34.0）

- ✅ `make c1-sidecar`（single）：istiod `pilot:1.29.4-debug`、CLUSTER_ID=cluster1，helloworld 回 v1
- ✅ `make c1c2-singlenet`（multi）：c1=cluster1 / c2=cluster2、image `1.29.4-debug`、remote secret 雙向
- ✅ `make c1c2-install-ewgw`：跨叢集 v1/v2 雙向、ewgw helloworld cluster 同時含本地 :5000 與對端 :15443

Closes #84