### PR TITLE
feat: support inline istio= version override in make targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .claude/settings.local.json
+config/.override.env

--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,12 @@ help:
 
 c1-sidecar:
 	@sed -i 's/^cluster_mode=.*/cluster_mode=single/' config/config.env
+	@bash scripts/apply_version_override.sh "$(istio)"
 	bash scripts/main.sh
 
 c1c2-singlenet:
 	@sed -i 's/^cluster_mode=.*/cluster_mode=multi/' config/config.env
+	@bash scripts/apply_version_override.sh "$(istio)"
 	bash scripts/main.sh
 
 c1c2-install-ewgw: c1c2-singlenet

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ kind-create-cluster/
    |---|---|---|---|---|---|
    | v0.30.0 | 1.29.4 | 1-29-4 | `kindest/node:v1.34.0`  | 1.31 – 1.35 | v1.34.8  |
    | v0.30.0 | 1.24.0 | 1-24-0 | `kindest/node:v1.31.12` | 1.28 – 1.31 | v1.31.6  |
-   | v0.14.0 | 1.13.5 | 1-13-5 | `kindest/node:v1.24.0`  | 1.20 – 1.24 | v1.24.17 |
+   | v0.14.0 | 1.13.5 | 1-13-5 | `kindest/node:v1.23.6`  | 1.20 – 1.24 | v1.23.17 |
 
    Fall-back default `node_image` when `node_image` is left empty (`scripts/create_cluster.sh`):
 

--- a/README.md
+++ b/README.md
@@ -48,8 +48,9 @@ kind-create-cluster/
 
    | kind_version | istio_version | istio_label | node_image (K8s) | Istio-supported K8s | kubectl_version |
    |---|---|---|---|---|---|
-   | v0.30.0 | 1.29.4 | 1-29-4 | `kindest/node:v1.34.0` | 1.31 – 1.35 | v1.34.8 |
-   | v0.30.0 | 1.24.0 | 1-24-0 | `kindest/node:v1.31.12` | 1.28 – 1.31 | v1.31.x |
+   | v0.30.0 | 1.29.4 | 1-29-4 | `kindest/node:v1.34.0`  | 1.31 – 1.35 | v1.34.8  |
+   | v0.30.0 | 1.24.0 | 1-24-0 | `kindest/node:v1.31.12` | 1.28 – 1.31 | v1.31.6  |
+   | v0.14.0 | 1.13.5 | 1-13-5 | `kindest/node:v1.24.0`  | 1.20 – 1.24 | v1.24.17 |
 
    Fall-back default `node_image` when `node_image` is left empty (`scripts/create_cluster.sh`):
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,19 @@ kind-create-cluster/
    | `make c1c2-install-ewgw` | Build dual clusters and install istio-eastwestgateway (includes c1c2-singlenet) |
    | `make clean` | Delete all kind clusters and clear download cache |
 
+   **Inline Istio version override** — pass `istio=<version>` to use a different Istio version without editing `config/config.env`:
+
+   ```bash
+   make c1-sidecar istio=1.13.5
+   make c1c2-singlenet istio=1.24.0
+   make c1c2-install-ewgw istio=1.29.4
+   ```
+
+   - Kind, K8s node image, and kubectl versions are resolved automatically from the built-in version matrix.
+   - If the version differs from the current `config/config.env` default, `make clean` is triggered automatically to clear stale cache.
+   - Passing an unsupported version prints an error with the supported version list.
+   - The override is **one-time only** — `config/config.env` is never modified.
+
 3. **Or run the script directly**
    ```
    # single cluster

--- a/config/config.env
+++ b/config/config.env
@@ -14,6 +14,8 @@ node_image="kindest/node:v1.34.0@sha256:7416a61b42b1662ca6ca89f02028ac133a309a2a
 kiali_version=v1.49.0 # kiali version: [ v1.49.0 ]（僅 vendored 此版，其餘版本已移除）
 kubectl_version=v1.34.8 # 建議對齊 node_image 的 K8s 版本（目前 v1.34 ↔ node v1.34.0）；version skew 一般容許 ±1 minor
 
+[ -f "$abspath/config/.override.env" ] && source "$abspath/config/.override.env"
+
 cluster_mode=multi
 
 available_processes=("main" "pretask" "create_kind_cluster" "istio" "prometheus" "kiali" "clear")

--- a/config/version-matrix.sh
+++ b/config/version-matrix.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Returns space-separated: kind_version node_image kubectl_version
+# Exits 1 for unknown versions.
+
+resolve_istio_versions() {
+    case "$1" in
+        1.13.5) echo "v0.14.0 kindest/node:v1.24.0 v1.24.17"  ;;
+        1.24.0) echo "v0.30.0 kindest/node:v1.31.12 v1.31.6"   ;;
+        1.29.4) echo "v0.30.0 kindest/node:v1.34.0 v1.34.8"    ;;
+        *)      return 1 ;;
+    esac
+}
+
+supported_istio_versions() {
+    echo "1.13.5  1.24.0  1.29.4"
+}

--- a/config/version-matrix.sh
+++ b/config/version-matrix.sh
@@ -4,7 +4,7 @@
 
 resolve_istio_versions() {
     case "$1" in
-        1.13.5) echo "v0.14.0 kindest/node:v1.24.0 v1.24.17"  ;;
+        1.13.5) echo "v0.14.0 kindest/node:v1.23.6 v1.23.17"   ;;
         1.24.0) echo "v0.30.0 kindest/node:v1.31.12 v1.31.6"   ;;
         1.29.4) echo "v0.30.0 kindest/node:v1.34.0 v1.34.8"    ;;
         *)      return 1 ;;

--- a/docs/superpowers/plans/2026-06-26-istio-version-override.md
+++ b/docs/superpowers/plans/2026-06-26-istio-version-override.md
@@ -1,0 +1,410 @@
+# Inline `istio=` Version Override Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Allow `make c1-sidecar istio=1.13.5` to automatically select the correct kind/K8s/kubectl versions without editing `config/config.env`.
+
+**Architecture:** A new `config/version-matrix.sh` holds the vetted version mapping. A new `scripts/apply_version_override.sh` reads the matrix, validates the requested version, then writes a temporary `config/.override.env`. `config/config.env` sources this override file in-place (after base vars, before derived paths) so all child scripts inherit it transparently. Makefile targets call the override script before `main.sh`.
+
+**Tech Stack:** Bash, GNU Make, kind, kubectl
+
+## Global Constraints
+
+- `config/.override.env` must be gitignored — never committed
+- Override source line in `config/config.env` must appear after line 15 (`kubectl_version=`) and before line 20 (`filtered_version_kiali=...`), so derived paths like `FOLDER_PATH_istio` are computed with the overridden `istio_version`
+- `apply_version_override.sh` must always delete stale `.override.env` at startup (even when called with no args), so bare `make` commands reliably restore defaults
+- `make -C "$abspath" clean` is called automatically when override version ≠ current `config.env` `istio_version`
+- Version matrix entries: `1.13.5 → v0.14.0 / kindest/node:v1.24.0 / v1.24.17`, `1.24.0 → v0.30.0 / kindest/node:v1.31.12 / v1.31.6`, `1.29.4 → v0.30.0 / kindest/node:v1.34.0 / v1.34.8`
+
+---
+
+## File Map
+
+| Action | Path | Responsibility |
+|--------|------|----------------|
+| Create | `config/version-matrix.sh` | Lookup table: istio_version → kind/node/kubectl |
+| Create | `scripts/apply_version_override.sh` | Validate, resolve, write `.override.env`, auto-clean |
+| Modify | `config/config.env` line 15→16 | Insert one `source .override.env` line |
+| Modify | `Makefile` | Add `@bash scripts/apply_version_override.sh "$(istio)"` to `c1-sidecar` and `c1c2-singlenet` |
+| Modify | `.gitignore` | Add `config/.override.env` |
+| Modify | `README.md` line 51–52 | Add `1.13.5` row to vetted combinations table |
+
+---
+
+### Task 1: Version matrix
+
+**Files:**
+- Create: `config/version-matrix.sh`
+
+**Interfaces:**
+- Produces:
+  - `resolve_istio_versions(version: string) → "kind_version node_image kubectl_version"` (space-separated, stdout) or returns 1
+  - `supported_istio_versions() → "1.13.5  1.24.0  1.29.4"` (stdout)
+
+- [ ] **Step 1: Create `config/version-matrix.sh`**
+
+```bash
+#!/usr/bin/env bash
+# Returns space-separated: kind_version node_image kubectl_version
+# Exits 1 for unknown versions.
+
+resolve_istio_versions() {
+    case "$1" in
+        1.13.5) echo "v0.14.0 kindest/node:v1.24.0 v1.24.17"  ;;
+        1.24.0) echo "v0.30.0 kindest/node:v1.31.12 v1.31.6"   ;;
+        1.29.4) echo "v0.30.0 kindest/node:v1.34.0 v1.34.8"    ;;
+        *)      return 1 ;;
+    esac
+}
+
+supported_istio_versions() {
+    echo "1.13.5  1.24.0  1.29.4"
+}
+```
+
+- [ ] **Step 2: 驗證 matrix 函數正確性**
+
+```bash
+source config/version-matrix.sh
+
+# 已知版本應回傳正確欄位
+result=$(resolve_istio_versions 1.13.5)
+echo "$result"
+# 預期輸出：v0.14.0 kindest/node:v1.24.0 v1.24.17
+
+result=$(resolve_istio_versions 1.29.4)
+echo "$result"
+# 預期輸出：v0.30.0 kindest/node:v1.34.0 v1.34.8
+
+# 未知版本應回傳 exit 1
+resolve_istio_versions 9.99.9; echo "exit=$?"
+# 預期輸出：exit=1
+
+# 支援清單
+supported_istio_versions
+# 預期輸出：1.13.5  1.24.0  1.29.4
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add config/version-matrix.sh
+git commit -m "feat: add version matrix for istio → kind/k8s/kubectl mapping"
+```
+
+---
+
+### Task 2: Override resolver script
+
+**Files:**
+- Create: `scripts/apply_version_override.sh`
+
+**Interfaces:**
+- Consumes:
+  - `resolve_istio_versions()` from `config/version-matrix.sh`
+  - `supported_istio_versions()` from `config/version-matrix.sh`
+  - `$1` — istio version string (may be empty)
+- Produces: `config/.override.env` (written when `$1` non-empty, deleted when empty or on script start)
+
+- [ ] **Step 1: Create `scripts/apply_version_override.sh`**
+
+```bash
+#!/usr/bin/env bash
+set -e
+
+abspath=$(cd "$(dirname "$0")/.."; pwd)
+OVERRIDE_FILE="$abspath/config/.override.env"
+
+# Always wipe stale override first (next bare `make` restores defaults)
+rm -f "$OVERRIDE_FILE"
+
+# No override requested
+[[ -z "$1" ]] && exit 0
+
+source "$abspath/config/version-matrix.sh"
+
+resolved=$(resolve_istio_versions "$1") || {
+    echo "Error: unsupported Istio version '$1'"
+    echo "Supported versions: $(supported_istio_versions)"
+    exit 1
+}
+
+read -r kind_ver node_img kubectl_ver <<< "$resolved"
+istio_label="${1//./-}"
+
+# Auto-clean when switching away from the current default
+current_istio=$(sed -n 's/^istio_version=\([^[:space:]#]*\).*/\1/p' \
+    "$abspath/config/config.env" | head -1)
+if [[ -n "$current_istio" && "$current_istio" != "$1" ]]; then
+    echo "Istio version changed ($current_istio → $1), running make clean …"
+    make -C "$abspath" clean
+fi
+
+cat > "$OVERRIDE_FILE" <<EOF
+istio_version=$1
+export istio_label=$istio_label
+kind_version=$kind_ver
+node_image="$node_img"
+kubectl_version=$kubectl_ver
+EOF
+
+echo "Version override: Istio $1 / kind $kind_ver / K8s ${node_img##*:} / kubectl $kubectl_ver"
+```
+
+- [ ] **Step 2: 驗證 — 無參數時刪除 override**
+
+先建一個假的 `.override.env`，確認腳本清除後正常 exit 0：
+
+```bash
+echo "test" > config/.override.env
+bash scripts/apply_version_override.sh
+echo "exit=$?"
+ls config/.override.env 2>/dev/null && echo "FAIL: file should be gone" || echo "PASS: file deleted"
+# 預期：exit=0，PASS: file deleted
+```
+
+- [ ] **Step 3: 驗證 — 已知版本寫入正確 override**
+
+```bash
+bash scripts/apply_version_override.sh 1.13.5
+echo "exit=$?"
+cat config/.override.env
+```
+
+預期輸出：
+```
+Version override: Istio 1.13.5 / kind v0.14.0 / K8s v1.24.0 / kubectl v1.24.17
+exit=0
+istio_version=1.13.5
+export istio_label=1-13-5
+kind_version=v0.14.0
+node_image="kindest/node:v1.24.0"
+kubectl_version=v1.24.17
+```
+
+- [ ] **Step 4: 驗證 — 未知版本報錯**
+
+```bash
+bash scripts/apply_version_override.sh 9.99.9
+echo "exit=$?"
+ls config/.override.env 2>/dev/null && echo "file exists" || echo "file absent"
+```
+
+預期輸出（stderr/stdout 混合）：
+```
+Error: unsupported Istio version '9.99.9'
+Supported versions: 1.13.5  1.24.0  1.29.4
+exit=1
+file absent
+```
+
+- [ ] **Step 5: 清除測試產物並 commit**
+
+```bash
+rm -f config/.override.env
+chmod +x scripts/apply_version_override.sh
+git add scripts/apply_version_override.sh
+git commit -m "feat: add apply_version_override.sh to resolve and apply istio version"
+```
+
+---
+
+### Task 3: Patch `config/config.env`
+
+**Files:**
+- Modify: `config/config.env` (insert 1 line between line 15 and line 17)
+
+**Interfaces:**
+- Consumes: `config/.override.env` (optionally present)
+- Produces: all scripts that source `config/config.env` now inherit the override transparently
+
+- [ ] **Step 1: 在 `kubectl_version=` 與 `cluster_mode=` 之間插入 override source**
+
+在 `config/config.env` 的這段：
+
+```
+kubectl_version=v1.34.8 # 建議對齊 ...
+                                          ← 在此空行插入
+cluster_mode=multi
+```
+
+插入後變成：
+
+```
+kubectl_version=v1.34.8 # 建議對齊 ...
+
+[ -f "$abspath/config/.override.env" ] && source "$abspath/config/.override.env"
+
+cluster_mode=multi
+```
+
+- [ ] **Step 2: 驗證 override 被 config.env 繼承，且衍生路徑正確**
+
+```bash
+# 先寫一個測試用 override
+cat > config/.override.env <<'EOF'
+istio_version=1.13.5
+export istio_label=1-13-5
+kind_version=v0.14.0
+node_image="kindest/node:v1.24.0"
+kubectl_version=v1.24.17
+EOF
+
+# Source config.env 並檢查變數
+abspath=$(pwd)
+source config/config.env
+echo "istio_version=$istio_version"
+echo "kind_version=$kind_version"
+echo "FOLDER_PATH_istio=$FOLDER_PATH_istio"
+echo "FILE_PATH_istio=$FILE_PATH_istio"
+```
+
+預期輸出：
+```
+istio_version=1.13.5
+kind_version=v0.14.0
+FOLDER_PATH_istio=/tmp/download/istio-1.13.5
+FILE_PATH_istio=<abspath>/tools/istio/operator/cluster-legacy.yaml
+```
+
+（`cluster-legacy.yaml` 因為 1.13 < 1.29）
+
+- [ ] **Step 3: 驗證無 override 時 config.env 行為不變**
+
+```bash
+rm -f config/.override.env
+abspath=$(pwd)
+source config/config.env
+echo "istio_version=$istio_version"
+echo "FOLDER_PATH_istio=$FOLDER_PATH_istio"
+```
+
+預期輸出：
+```
+istio_version=1.29.4
+FOLDER_PATH_istio=/tmp/download/istio-1.29.4
+```
+
+- [ ] **Step 4: 清除測試產物並 commit**
+
+```bash
+rm -f config/.override.env
+git add config/config.env
+git commit -m "feat: source .override.env in config.env before derived paths"
+```
+
+---
+
+### Task 4: Patch Makefile
+
+**Files:**
+- Modify: `Makefile`
+
+**Interfaces:**
+- Consumes: `scripts/apply_version_override.sh`
+- Produces: `make c1-sidecar istio=X` and `make c1c2-singlenet istio=X` work end-to-end
+
+- [ ] **Step 1: 修改 `c1-sidecar` 與 `c1c2-singlenet` 加入 override 呼叫**
+
+目前：
+```makefile
+c1-sidecar:
+	@sed -i 's/^cluster_mode=.*/cluster_mode=single/' config/config.env
+	bash scripts/main.sh
+
+c1c2-singlenet:
+	@sed -i 's/^cluster_mode=.*/cluster_mode=multi/' config/config.env
+	bash scripts/main.sh
+```
+
+改為：
+```makefile
+c1-sidecar:
+	@sed -i 's/^cluster_mode=.*/cluster_mode=single/' config/config.env
+	@bash scripts/apply_version_override.sh "$(istio)"
+	bash scripts/main.sh
+
+c1c2-singlenet:
+	@sed -i 's/^cluster_mode=.*/cluster_mode=multi/' config/config.env
+	@bash scripts/apply_version_override.sh "$(istio)"
+	bash scripts/main.sh
+```
+
+- [ ] **Step 2: 驗證 dry-run 顯示正確命令序列**
+
+```bash
+make -n c1-sidecar istio=1.13.5
+```
+
+預期輸出（順序）：
+```
+sed -i 's/^cluster_mode=.*/cluster_mode=single/' config/config.env
+bash scripts/apply_version_override.sh "1.13.5"
+bash scripts/main.sh
+```
+
+```bash
+make -n c1-sidecar
+```
+
+預期輸出：
+```
+sed -i 's/^cluster_mode=.*/cluster_mode=single/' config/config.env
+bash scripts/apply_version_override.sh ""
+bash scripts/main.sh
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Makefile
+git commit -m "feat: pass istio= override to make targets via apply_version_override.sh"
+```
+
+---
+
+### Task 5: gitignore + README
+
+**Files:**
+- Modify: `.gitignore`
+- Modify: `README.md` (line 51–52)
+
+- [ ] **Step 1: 加入 `.gitignore` 條目**
+
+在 `.gitignore` 尾端加入：
+```
+config/.override.env
+```
+
+驗證：
+```bash
+echo "test" > config/.override.env
+git status
+# config/.override.env 不應出現在 untracked files
+git status | grep override && echo "FAIL" || echo "PASS: correctly ignored"
+rm config/.override.env
+```
+
+- [ ] **Step 2: README 補 1.13.5 vetted combination**
+
+在 `README.md` 的版本對照表：
+
+目前（line 51–52）：
+```markdown
+   | v0.30.0 | 1.29.4 | 1-29-4 | `kindest/node:v1.34.0` | 1.31 – 1.35 | v1.34.8 |
+   | v0.30.0 | 1.24.0 | 1-24-0 | `kindest/node:v1.31.12` | 1.28 – 1.31 | v1.31.x |
+```
+
+改為（新增最後一行）：
+```markdown
+   | v0.30.0 | 1.29.4 | 1-29-4 | `kindest/node:v1.34.0`  | 1.31 – 1.35 | v1.34.8  |
+   | v0.30.0 | 1.24.0 | 1-24-0 | `kindest/node:v1.31.12` | 1.28 – 1.31 | v1.31.6  |
+   | v0.14.0 | 1.13.5 | 1-13-5 | `kindest/node:v1.24.0`  | 1.20 – 1.24 | v1.24.17 |
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .gitignore README.md
+git commit -m "chore: gitignore .override.env and add 1.13.5 to README version matrix"
+```

--- a/docs/superpowers/specs/2026-06-26-istio-version-override-design.md
+++ b/docs/superpowers/specs/2026-06-26-istio-version-override-design.md
@@ -1,0 +1,161 @@
+# Design: Inline `istio=` Version Override for Make Targets
+
+**Issue:** #87
+**Branch:** 87-istio-version-override
+**Date:** 2026-06-26
+
+---
+
+## 問題背景
+
+切換 Istio 版本需手動修改 `config/config.env` 的 5 個欄位（`istio_version`、`istio_label`、`kind_version`、`node_image`、`kubectl_version`），容易出錯，且未先 `make clean` 會讓 pretask 靜默沿用舊版 tarball。
+
+## 目標 UX
+
+```bash
+make c1-sidecar istio=1.13.5
+make c1c2-singlenet istio=1.24.0
+```
+
+- `istio=` 為一次性 override，**不修改 config.env**
+- 未傳 `istio=` 時維持原行為
+- 傳入不在 matrix 的版本 → 報錯並列出支援清單，停止執行
+- 傳入版本與 config.env 目前值不同 → 自動先執行 clean
+
+---
+
+## 架構
+
+```
+make c1-sidecar istio=1.13.5
+        │
+        ▼
+  [Makefile] 偵測到 istio= 變數
+        │
+        ├─ 不在 matrix → 印錯誤 + 支援清單 → exit 1
+        │
+        ├─ 版本與 config.env 現有 istio_version 不同 → make clean
+        │
+        ├─ 查 config/version-matrix.sh → 解析 kind/node/kubectl
+        │
+        ├─ 寫入 config/.override.env（暫存，gitignored）
+        │
+        ├─ bash scripts/main.sh
+        │       ↓
+        │   source config/config.env
+        │       ↓（config.env 最後一行）
+        │   source config/.override.env  ← 蓋掉版本相關變數
+        │
+        └─ 清除 config/.override.env（無論成功/失敗皆清除）
+```
+
+---
+
+## 修改/新增檔案
+
+| 檔案 | 動作 | 說明 |
+|------|------|------|
+| `config/version-matrix.sh` | 新增 | 版本對照表 |
+| `scripts/apply_version_override.sh` | 新增 | 解析 matrix、寫 override、觸發 clean |
+| `config/config.env` | 修改 1 行 | 最後加 source `.override.env` |
+| `Makefile` | 修改 | 各 target 加 `istio=` 處理 |
+| `.gitignore` | 修改 | 加入 `config/.override.env` |
+| `README.md` | 修改 | vetted combinations 補 1.13.5 |
+
+---
+
+## `config/version-matrix.sh`
+
+```bash
+# 回傳格式：kind_version node_image kubectl_version
+resolve_istio_versions() {
+    case "$1" in
+        1.13.5) echo "v0.14.0 kindest/node:v1.24.0 v1.24.17" ;;
+        1.24.0) echo "v0.30.0 kindest/node:v1.31.12 v1.31.6"  ;;
+        1.29.4) echo "v0.30.0 kindest/node:v1.34.0 v1.34.8"   ;;
+        *)      return 1 ;;
+    esac
+}
+
+supported_istio_versions() {
+    echo "1.13.5  1.24.0  1.29.4"
+}
+```
+
+`istio_label` 從 `istio_version` 計算（`.` → `-`），不進 matrix。
+
+---
+
+## `scripts/apply_version_override.sh`
+
+邏輯：
+1. 無論如何，**先刪除** `config/.override.env`（清除上次的殘留）
+2. `$1` 空 → return 0（bare make 恢復 config.env 預設）
+3. `source config/version-matrix.sh`；呼叫 `resolve_istio_versions "$1"`
+4. 失敗 → 印錯誤 + `supported_istio_versions` → exit 1
+5. 讀取 config.env 目前 `istio_version`；若不同 → `make -C "$abspath" clean`
+6. 計算 `istio_label="${1//./-}"`
+7. 寫入 `config/.override.env`：
+   ```
+   istio_version=1.13.5
+   istio_label=1-13-5
+   kind_version=v0.14.0
+   node_image=kindest/node:v1.24.0
+   kubectl_version=v1.24.17
+   ```
+
+---
+
+## `config/config.env` 修改
+
+在檔案最後加一行：
+
+```bash
+[ -f "$abspath/config/.override.env" ] && source "$abspath/config/.override.env"
+```
+
+---
+
+## Makefile 修改
+
+```makefile
+c1-sidecar:
+    @sed -i 's/^cluster_mode=.*/cluster_mode=single/' config/config.env
+    @bash scripts/apply_version_override.sh "$(istio)"
+    bash scripts/main.sh
+
+c1c2-singlenet:
+    @sed -i 's/^cluster_mode=.*/cluster_mode=multi/' config/config.env
+    @bash scripts/apply_version_override.sh "$(istio)"
+    bash scripts/main.sh
+```
+
+Makefile 不負責刪除 `.override.env`。cleanup 發生在「下一次 make 的 `apply_version_override.sh` 執行開頭」。
+
+### c1c2-install-ewgw 的行為
+
+```
+make c1c2-install-ewgw istio=1.13.5
+  └─ [prereq] c1c2-singlenet
+       ├─ apply_version_override.sh "1.13.5"  → 清舊 override → 寫新 override
+       └─ main.sh → source config.env → source .override.env → 使用 1.13.5 ✓
+  └─ install_eastwestgateway.sh → source config.env → source .override.env → 使用 1.13.5 ✓
+```
+
+`.override.env` 留至下次 make 時被清除（gitignored）。
+
+---
+
+## 錯誤訊息格式
+
+```
+Error: unsupported Istio version '1.99.0'
+Supported versions: 1.13.5  1.24.0  1.29.4
+```
+
+---
+
+## 不在此 issue 範圍
+
+- ambient mode 的 istio= 支援（目前無 ambient make target）
+- 動態新增版本至 matrix（手動維護 version-matrix.sh）

--- a/scripts/apply_version_override.sh
+++ b/scripts/apply_version_override.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -e
+
+abspath=$(cd "$(dirname "$0")/.."; pwd)
+OVERRIDE_FILE="$abspath/config/.override.env"
+
+# Always wipe stale override first (next bare `make` restores defaults)
+rm -f "$OVERRIDE_FILE"
+
+# No override requested
+[[ -z "$1" ]] && exit 0
+
+source "$abspath/config/version-matrix.sh"
+
+resolved=$(resolve_istio_versions "$1") || {
+    echo "Error: unsupported Istio version '$1'"
+    echo "Supported versions: $(supported_istio_versions)"
+    exit 1
+}
+
+read -r kind_ver node_img kubectl_ver <<< "$resolved"
+istio_label="${1//./-}"
+
+# Auto-clean when switching away from the current default
+current_istio=$(sed -n 's/^istio_version=\([^[:space:]#]*\).*/\1/p' \
+    "$abspath/config/config.env" | head -1)
+if [[ -n "$current_istio" && "$current_istio" != "$1" ]]; then
+    echo "Istio version changed ($current_istio → $1), running make clean …"
+    make -C "$abspath" clean
+fi
+
+cat > "$OVERRIDE_FILE" <<EOF
+istio_version=$1
+export istio_label=$istio_label
+kind_version=$kind_ver
+node_image="$node_img"
+kubectl_version=$kubectl_ver
+EOF
+
+echo "Version override: Istio $1 / kind $kind_ver / K8s ${node_img##*:} / kubectl $kubectl_ver"

--- a/tools/istio/operator/cluster-legacy.yaml
+++ b/tools/istio/operator/cluster-legacy.yaml
@@ -36,7 +36,6 @@ spec:
             value: 1
   values:
     global:
-      variant: debug
       meshID: mesh1
       # cluster 差異參數化：由安裝腳本 envsubst 帶入每個 cluster 的值
       #   c1（multi / single 共用）：CLUSTER_NAME=cluster1 NETWORK_NAME=$NETWORK_CLUSTER1


### PR DESCRIPTION
## 功能說明

新增 `istio=` inline 參數支援，無需手動修改 `config/config.env` 即可切換 Istio 版本：

```bash
make c1-sidecar istio=1.13.5
make c1c2-singlenet istio=1.24.0
make c1c2-install-ewgw istio=1.29.4
```

## 異動內容

- **`config/version-matrix.sh`**（新增）：Istio → kind / node_image / kubectl 版本對照表
- **`scripts/apply_version_override.sh`**（新增）：解析 matrix、寫入暫存 `.override.env`、版本切換時自動 `make clean`
- **`config/config.env`**：在衍生路徑計算之前 source `.override.env`，確保 `FOLDER_PATH_istio` 等路徑正確
- **`Makefile`**：`c1-sidecar` / `c1c2-singlenet` 加入 `apply_version_override.sh` 呼叫
- **`tools/istio/operator/cluster-legacy.yaml`**：移除 `variant: debug`（Istio 1.21+ 才有，1.13.x 不相容）
- **`README.md`**：vetted combinations 補 Istio 1.13.5（kind v0.14.0 / K8s v1.23.6）
- **`.gitignore`**：加入 `config/.override.env`

## 設計重點

- `istio=` 為**一次性 override**，不修改 `config/config.env`
- 每次 make 開始時自動清除殘留 `.override.env`，bare `make` 自然恢復預設
- 未知版本報錯並列出支援清單
- `c1c2-install-ewgw` 透過依賴鏈自然繼承 override（不需額外處理）

## 驗證結果

三個 make target 以 `istio=1.13.5` 實機驗證通過：
- `make c1-sidecar istio=1.13.5` ✅
- `make c1c2-singlenet istio=1.13.5` ✅
- `make c1c2-install-ewgw istio=1.13.5` ✅

Closes #87