### PR TITLE
chore: reduce istio 1.29.4 to kind v0.30.0 to minimize kind binary count

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ kind-create-cluster/
 
    | Component | Version | Kubernetes |
    |---|---|---|
-   | kind | v0.32.0 | v1.34.8 |
+   | kind | v0.30.0 | v1.34.0 |
    | Istio | 1.29.4 | 1.31 – 1.35 |
    | Kiali | v1.49.0 | — |
 
@@ -48,16 +48,24 @@ kind-create-cluster/
 
    | kind_version | istio_version | istio_label | node_image (K8s) | Istio-supported K8s | kubectl_version |
    |---|---|---|---|---|---|
-   | v0.32.0 **(default)** | 1.29.4 | 1-29-4 | `kindest/node:v1.34.8`  | 1.31 – 1.35 | v1.34.8  |
-   | v0.30.0 | 1.29.4 | 1-29-4 | `kindest/node:v1.34.0`  | 1.31 – 1.35 | v1.34.8  |
+   | v0.30.0 **(default)** | 1.29.4 | 1-29-4 | `kindest/node:v1.34.0`  | 1.31 – 1.35 | v1.34.8  |
    | v0.30.0 | 1.24.0 | 1-24-0 | `kindest/node:v1.31.12` | 1.28 – 1.31 | v1.31.6  |
    | v0.14.0 | 1.13.5 | 1-13-5 | `kindest/node:v1.23.6`  | 1.20 – 1.24 | v1.23.17 |
+   | v0.32.0 | 1.29.4 | 1-29-4 | `kindest/node:v1.34.8`  | 1.31 – 1.35 | v1.34.8  |
 
-   kind v0.32.0 ships four node images — `v1.36.1`（預設）/ `v1.35.5` / `v1.34.8` /
-   `v1.33.12`. Note the **default** (`v1.36.1`) falls *outside* Istio 1.29.4's supported
-   K8s range (1.31 – 1.35), so it must not be left empty for this combination — pin
-   `node_image` explicitly to `v1.35.5` or `v1.34.8`. Also note kind v0.32.0 dropped
-   support for `v1.32.x` / `v1.31.x` node images that earlier kind versions shipped.
+   `kind_version=v0.30.0` is deliberately shared between istio 1.24.0 and 1.29.4 — its
+   node image lineup (`v1.34.0` / `v1.33.4` / `v1.32.8` / `v1.31.12`) already covers both
+   Istio ranges, so there's no need to also maintain kind v0.32.0 as a second binary just
+   for 1.29.4. Only two kind binaries are needed in total for all three vetted Istio
+   versions: `v0.14.0` (for 1.13.5, whose 1.20–1.24 range no newer kind ships images for)
+   and `v0.30.0` (for 1.24.0 and 1.29.4).
+
+   kind v0.32.0 remains a valid alternative for 1.29.4 if you want a newer kind binary —
+   it ships four node images: `v1.36.1`（預設）/ `v1.35.5` / `v1.34.8` / `v1.33.12`. Note
+   the **default** (`v1.36.1`) falls *outside* Istio 1.29.4's supported K8s range
+   (1.31 – 1.35), so it must not be left empty for this combination — pin `node_image`
+   explicitly to `v1.35.5` or `v1.34.8`. Also note kind v0.32.0 dropped support for
+   `v1.32.x` / `v1.31.x` node images that earlier kind versions shipped.
 
    **Extending the matrix to a new Istio version**
 

--- a/config/config.env
+++ b/config/config.env
@@ -3,16 +3,18 @@ export CTX_CLUSTER2=kind-c2
 export NETWORK_CLUSTER1=network1
 export NETWORK_CLUSTER2=network1
 
-kind_version=v0.32.0 # kind binary 版本 : [ v0.14.0 , v0.23.0 , v0.26.0 , v0.30.0 , v0.32.0 ]
+kind_version=v0.30.0 # kind binary 版本 : [ v0.14.0 , v0.23.0 , v0.26.0 , v0.30.0 , v0.32.0 ]
 istio_version=1.29.4  # istio vesion（可用 make ... istio=<version> override，見 config/version-matrix.sh）: [ 1.13.5 , 1.24.0 , 1.29.4 ]（vetted） / [ 1.25.5 , 1.26.8 , 1.27.9 , 1.28.10 ]（candidate，未在本 repo 實測）
 export istio_label=1-29-4  # istio vesion : [ 1-13-5 , 1-24-0 , 1-29-4 ]（vetted） / [ 1-25-5 , 1-26-8 , 1-27-9 , 1-28-10 ]（candidate）
 # k8s node image：決定叢集 K8s 版本，與 kind binary 及 istio_version 各自獨立。
 # 須為 kind_version 所支援的 image；留空則 fall back 至 kind_version 對應的預設 image。
-# kind v0.32.0 支援：v1.36.1（預設，超出 Istio 1.29.4 支援範圍 1.31–1.35，勿留空）/ v1.35.5 / v1.34.8 / v1.33.12
+# kind v0.30.0 支援：v1.34.0 / v1.33.4 / v1.32.8 / v1.31.12
 # 版本對照（Istio ↔ 支援 K8s）詳見 README.md 版本對照表。
-node_image="kindest/node:v1.34.8@sha256:02722c2dedddcfc00febf5d27fbeb9b7b2c14294c82109ff4a85d89ac9ba3256"
+# 註：istio 1.24.0 與 1.29.4 皆刻意共用 kind v0.30.0，只需維護 v0.14.0 + v0.30.0
+# 兩個 kind binary 即可涵蓋 1.13.5 / 1.24.0 / 1.29.4 三組（見 README「Extending the matrix」）。
+node_image="kindest/node:v1.34.0@sha256:7416a61b42b1662ca6ca89f02028ac133a309a2a30ba309614e8ec94d976dc5a"
 kiali_version=v1.49.0 # kiali version: [ v1.49.0 ]（僅 vendored 此版，其餘版本已移除）
-kubectl_version=v1.34.8 # 建議對齊 node_image 的 K8s 版本（目前 v1.34 ↔ node v1.34.8，精確對齊）；version skew 一般容許 ±1 minor
+kubectl_version=v1.34.8 # 建議對齊 node_image 的 K8s 版本（目前 v1.34 ↔ node v1.34.0）；version skew 一般容許 ±1 minor
 
 [ -f "$abspath/config/.override.env" ] && source "$abspath/config/.override.env"
 

--- a/config/version-matrix.sh
+++ b/config/version-matrix.sh
@@ -6,7 +6,7 @@ resolve_istio_versions() {
     case "$1" in
         1.13.5)  echo "v0.14.0 kindest/node:v1.23.6 v1.23.17"   ;;
         1.24.0)  echo "v0.30.0 kindest/node:v1.31.12 v1.31.6"   ;;
-        1.29.4)  echo "v0.32.0 kindest/node:v1.34.8 v1.34.8"    ;;
+        1.29.4)  echo "v0.30.0 kindest/node:v1.34.0 v1.34.8"    ;;
         # Candidate — derived from Istio's supported-K8s table, not yet cluster-tested
         # in this repo. See README.md "Extending the matrix" for how these were picked.
         1.25.5)  echo "v0.30.0 kindest/node:v1.31.12 v1.31.12"  ;;


### PR DESCRIPTION
## Summary
- kind v0.30.0's node_image lineup covers both istio 1.24.0 and 1.29.4's supported K8s ranges, so istio 1.29.4 no longer needs its own kind v0.32.0 binary.
- `config/version-matrix.sh`: istio 1.29.4 → kind v0.30.0 / node v1.34.0
- `config/config.env`: default reverted to kind_version=v0.30.0 / node_image=v1.34.0
- `README.md`: default marker moved to v0.30.0 row; v0.32.0 kept documented as a valid alternative; added a note explaining only 2 kind binaries (v0.14.0 + v0.30.0) are needed to cover all 3 vetted istio versions

Closes #93

## Test plan
- [x] `bash -n` syntax check on `config/config.env`, `config/version-matrix.sh`
- [x] `resolve_istio_versions` verified for 1.13.5 / 1.24.0 / 1.29.4