### PR TITLE
fix: stop mutating tracked config.env for cluster_mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,13 +8,11 @@ help:
 	@echo "  make clean               Delete all kind clusters and clear download cache"
 
 c1-sidecar:
-	@sed -i 's/^cluster_mode=.*/cluster_mode=single/' config/config.env
-	@bash scripts/apply_version_override.sh "$(istio)"
+	@bash scripts/apply_version_override.sh "$(istio)" single
 	bash scripts/main.sh
 
 c1c2-singlenet:
-	@sed -i 's/^cluster_mode=.*/cluster_mode=multi/' config/config.env
-	@bash scripts/apply_version_override.sh "$(istio)"
+	@bash scripts/apply_version_override.sh "$(istio)" multi
 	bash scripts/main.sh
 
 c1c2-install-ewgw: c1c2-singlenet

--- a/config/config.env
+++ b/config/config.env
@@ -18,7 +18,7 @@ kubectl_version=v1.34.8 # 建議對齊 node_image 的 K8s 版本（目前 v1.34 
 
 [ -f "$abspath/config/.override.env" ] && source "$abspath/config/.override.env"
 
-cluster_mode=multi
+: "${cluster_mode:=single}"
 
 available_processes=("main" "pretask" "create_kind_cluster" "istio" "prometheus" "kiali" "clear")
 filtered_version_kiali=$(echo "$kiali_version" | tr -d 'v')

--- a/scripts/apply_version_override.sh
+++ b/scripts/apply_version_override.sh
@@ -3,12 +3,17 @@ set -e
 
 abspath=$(cd "$(dirname "$0")/.."; pwd)
 OVERRIDE_FILE="$abspath/config/.override.env"
+cluster_mode="$2"
 
 # Always wipe stale override first (next bare `make` restores defaults)
 rm -f "$OVERRIDE_FILE"
 
-# No override requested
-[[ -z "$1" ]] && exit 0
+# No istio override requested: still record cluster_mode (if any) so the
+# Makefile never has to mutate the git-tracked config.env.
+if [[ -z "$1" ]]; then
+    [[ -n "$cluster_mode" ]] && echo "cluster_mode=$cluster_mode" > "$OVERRIDE_FILE"
+    exit 0
+fi
 
 source "$abspath/config/version-matrix.sh"
 
@@ -36,5 +41,6 @@ kind_version=$kind_ver
 node_image="$node_img"
 kubectl_version=$kubectl_ver
 EOF
+[[ -n "$cluster_mode" ]] && echo "cluster_mode=$cluster_mode" >> "$OVERRIDE_FILE"
 
 echo "Version override: Istio $1 / kind $kind_ver / K8s ${node_img##*:} / kubectl $kubectl_ver"


### PR DESCRIPTION
## 問題
`cluster_mode` 目前透過 Makefile 的 `sed -i` 直接寫入 git tracked 的 `config/config.env`，導致每次 `make c1-sidecar` / `make c1c2-singlenet` 都會產生假的 git diff。

## 修法
比照 istio 版本 override 機制，改用已被 `.gitignore` 的 `config/.override.env` 存放 `cluster_mode`：
- `Makefile`：不再 sed `config.env`，改把 `single`/`multi` 當參數傳給 `apply_version_override.sh`
- `apply_version_override.sh`：即使沒有帶 `istio=`，也能單獨把 `cluster_mode` 寫進 `.override.env`
- `config/config.env`：`cluster_mode=multi` 改成 `: "${cluster_mode:=single}"`，只有在 override 沒設定時才套用預設值

## 驗收
已手動測試 `apply_version_override.sh` 在三種情境（僅 cluster_mode / istio+cluster_mode / 無 override）下都正確寫入 `.override.env`，且執行後 `config/config.env` 不再出現在 `git status`。

Closes #96