### PR TITLE
feat: tee make run output to timestamped log file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,18 @@
-.PHONY: help c1-sidecar c1c2-singlenet c1c2-install-ewgw clean
+SHELL := /bin/bash
+LOG_DIR ?= /tmp/kind-create-cluster-logs
+
+.PHONY: help c1-sidecar c1c2-singlenet c1c2-install-ewgw clean \
+	_c1-sidecar _c1c2-singlenet _c1c2-install-ewgw
+
+# Wrap $(2) (the real target) with tee-to-timestamped-log-file, preserving
+# real-time terminal output and the underlying command's exit code.
+define run_logged
+	@mkdir -p "$(LOG_DIR)"
+	@_f="$(LOG_DIR)/$(1)-$(if $(istio),$(istio),default)-$(shell date +%Y%m%d-%H%M%S).log"; \
+	 printf "[log] $$_f\n"; \
+	 $(MAKE) --no-print-directory $(2) istio=$(istio) 2>&1 | tee "$$_f"; \
+	 _rc=$${PIPESTATUS[0]}; printf "[log saved] $$_f\n"; exit $$_rc
+endef
 
 help:
 	@echo "Usage:"
@@ -6,16 +20,27 @@ help:
 	@echo "  make c1c2-singlenet      Create dual clusters (c1 + c2) with sidecar mode Istio multi-primary mesh (single network)"
 	@echo "  make c1c2-install-ewgw   Install istio-eastwestgateway on c1 and c2 clusters"
 	@echo "  make clean               Delete all kind clusters and clear download cache"
+	@echo ""
+	@echo "Each run is teed to a timestamped log file under $(LOG_DIR) (override with LOG_DIR=...)."
 
 c1-sidecar:
+	$(call run_logged,c1-sidecar,_c1-sidecar)
+
+c1c2-singlenet:
+	$(call run_logged,c1c2-singlenet,_c1c2-singlenet)
+
+c1c2-install-ewgw:
+	$(call run_logged,c1c2-install-ewgw,_c1c2-install-ewgw)
+
+_c1-sidecar:
 	@bash scripts/apply_version_override.sh "$(istio)" single
 	bash scripts/main.sh
 
-c1c2-singlenet:
+_c1c2-singlenet:
 	@bash scripts/apply_version_override.sh "$(istio)" multi
 	bash scripts/main.sh
 
-c1c2-install-ewgw: c1c2-singlenet
+_c1c2-install-ewgw: _c1c2-singlenet
 	bash scripts/install_eastwestgateway.sh
 
 clean:

--- a/README.md
+++ b/README.md
@@ -146,6 +146,18 @@ kind-create-cluster/
    - Passing an unsupported version prints an error with the supported version list.
    - The override is **one-time only** — `config/config.env` is never modified.
 
+   **Log output** — every run is teed to a timestamped log file under `/tmp/kind-create-cluster-logs/`
+   (not tracked in git), so a failed run can be inspected after the terminal is gone:
+
+   ```
+   [log] /tmp/kind-create-cluster-logs/c1-sidecar-1.29.4-20260710-143022.log
+   ...
+   [log saved] /tmp/kind-create-cluster-logs/c1-sidecar-1.29.4-20260710-143022.log
+   ```
+
+   Override the directory with `LOG_DIR=...`. The command's exit code still propagates
+   through `tee`, so CI/script failures are still detected correctly.
+
 3. **Or run the script directly**
    ```
    # single cluster


### PR DESCRIPTION
## 內容
參考 `istio-upgrade-e2e` 的 log 輸出設計，`c1-sidecar` / `c1c2-singlenet` / `c1c2-install-ewgw` 三個 target 現在都會：
- 執行前印出 `[log] <path>`
- 透過 `tee` 把完整輸出寫入 `/tmp/kind-create-cluster-logs/<target>-<istio version>-<timestamp>.log`（不進 git）
- 執行後印出 `[log saved] <path>`
- 用 `PIPESTATUS` 保留底層指令的 exit code，不會因為接了 tee 而變成 0

實作方式：Makefile 新增 `run_logged` macro 統一包裝三個公開 target，實際邏輯移到底線開頭的 internal target（`_c1-sidecar` / `_c1c2-singlenet` / `_c1c2-install-ewgw`），`c1c2-install-ewgw` 整個流程（含 singlenet 建立 + east-west gateway 安裝）只產生一份 log。另外加上 `SHELL := /bin/bash`，因為 `${PIPESTATUS[0]}` 是 bash-only 語法（預設 make 用 `/bin/sh` 會炸 `Bad substitution`）。

## 驗收
本地以 dummy Makefile 測試（成功 / 失敗兩種情境）驗證：
- terminal 即時輸出與 log 檔內容一致
- 失敗時 exit code 正確非 0 傳遞（不會因為 tee 而變成 0）
- `make -n c1c2-install-ewgw` 確認只會產生一份 log（singlenet + ewgw 合併在同一次執行內）

README 同步補充 Log 輸出說明。

Closes #99